### PR TITLE
fix: add right padding to error banner to avoid ToDo panel overlap

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -5,6 +5,7 @@ import { useNavigation } from './hooks/useNavigation';
 import { AskUserQuestion, LoadingIndicator, MessageStream, InputArea, NewSessionModal, PermissionRequest, Sidebar, Toast, WelcomePage, NavRail, SettingsPage, UsagePage } from './components';
 import type { MessageStreamHandle } from './components/MessageStream';
 import { BrowserView } from './components/BrowserView';
+import { ErrorBanner } from './components/ErrorBanner';
 import { TodoPanel } from './components/TodoPanel';
 import { ViewToggle, type SessionView } from './components/ViewToggle';
 import type { SidebarSession } from './components';
@@ -346,11 +347,7 @@ function App() {
             </div>
 
             {/* Error banner */}
-            {error && (
-              <div className="px-4 py-2 bg-accent-danger/10 border-b border-accent-danger text-accent-danger">
-                {error}
-              </div>
-            )}
+            <ErrorBanner error={error} />
 
             {/* Main content */}
             <main className="flex-1 flex flex-col overflow-hidden">

--- a/packages/client/src/components/ErrorBanner.tsx
+++ b/packages/client/src/components/ErrorBanner.tsx
@@ -1,0 +1,18 @@
+interface ErrorBannerProps {
+  error: string | null;
+}
+
+export function ErrorBanner({ error }: ErrorBannerProps) {
+  if (!error) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="error-banner"
+      className="px-4 py-2 pr-28 bg-accent-danger/10 border-b border-accent-danger text-accent-danger"
+    >
+      {error}
+    </div>
+  );
+}

--- a/packages/client/src/components/__tests__/ErrorBanner.test.tsx
+++ b/packages/client/src/components/__tests__/ErrorBanner.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ErrorBanner } from '../ErrorBanner';
+
+describe('ErrorBanner', () => {
+  it('should render error message when error is provided', () => {
+    render(<ErrorBanner error="Something went wrong" />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('should not render when error is null', () => {
+    const { container } = render(<ErrorBanner error={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should not render when error is empty string', () => {
+    const { container } = render(<ErrorBanner error="" />);
+
+    // empty string is falsy, so should not render
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should have right padding to avoid overlapping with ToDo panel', () => {
+    render(<ErrorBanner error="Test error" />);
+
+    const banner = screen.getByTestId('error-banner');
+    // pr-28 = 112px padding-right to avoid overlapping with collapsed ToDo panel
+    expect(banner).toHaveClass('pr-28');
+  });
+
+  it('should have danger styling', () => {
+    render(<ErrorBanner error="Test error" />);
+
+    const banner = screen.getByTestId('error-banner');
+    expect(banner).toHaveClass('bg-accent-danger/10');
+    expect(banner).toHaveClass('border-accent-danger');
+    expect(banner).toHaveClass('text-accent-danger');
+  });
+});
+
+describe('ErrorBanner robustness', () => {
+  it('should handle very long error messages without breaking layout', () => {
+    const longError = 'A'.repeat(1000);
+
+    expect(() => render(<ErrorBanner error={longError} />)).not.toThrow();
+    expect(screen.getByText(longError)).toBeInTheDocument();
+  });
+
+  it('should handle error messages with special characters', () => {
+    const specialError = '<script>alert("xss")</script> & "quotes" \'single\'';
+
+    expect(() => render(<ErrorBanner error={specialError} />)).not.toThrow();
+    // React escapes special characters by default
+    expect(screen.getByTestId('error-banner')).toHaveTextContent(specialError);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract error banner into a standalone `ErrorBanner` component
- Add `pr-28` (112px) right padding so it doesn't overlap with the collapsed ToDo panel button
- Add tests for the ErrorBanner component including robustness tests

## Test plan
- [x] All existing tests pass
- [x] New ErrorBanner tests pass (7 tests)
- [x] Type check passes
- [ ] Manual verification: error banner no longer overlaps with collapsed ToDo panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)