### PR TITLE
feat: change default permission mode to plan

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -516,7 +516,8 @@ export function createServer(options: ServerOptions): BridgeServer {
         'auto-edit': 'acceptEdits',
         'plan': 'plan',
       };
-      const permissionMode = session.permissionMode ? modeMap[session.permissionMode] : undefined;
+      const sessionMode = session.permissionMode ?? settingsManager.get('defaultPermissionMode');
+      const permissionMode = modeMap[sessionMode];
 
       runnerManager.startSession(sessionId, content, {
         workingDir: session.workingDir,
@@ -950,9 +951,9 @@ export function createServer(options: ServerOptions): BridgeServer {
           const hasBrowserSession = browserSessionManager.getController(message.sessionId) !== undefined;
 
           // Get current permission mode for sync
-          // Priority: runner's current mode > session's stored mode
+          // Priority: runner's current mode > session's stored mode > global default
           const runner = runnerManager.getRunner(message.sessionId);
-          let currentMode: PermissionMode | undefined;
+          let currentMode: PermissionMode;
           if (runner) {
             // Map ClaudePermissionMode to PermissionMode
             const reverseMap: Record<ClaudePermissionMode, PermissionMode> = {
@@ -964,6 +965,9 @@ export function createServer(options: ServerOptions): BridgeServer {
           } else if (session.permissionMode) {
             // Use stored session permission mode
             currentMode = session.permissionMode;
+          } else {
+            // Fall back to global default
+            currentMode = settingsManager.get('defaultPermissionMode') as PermissionMode;
           }
 
           response = {
@@ -1268,7 +1272,8 @@ export function createServer(options: ServerOptions): BridgeServer {
             'auto-edit': 'acceptEdits',
             'plan': 'plan',
           };
-          const permissionMode = session.permissionMode ? modeMap[session.permissionMode] : undefined;
+          const sessionMode = session.permissionMode ?? settingsManager.get('defaultPermissionMode');
+          const permissionMode = modeMap[sessionMode];
 
           runnerManager.startSession(message.sessionId, message.content, {
             workingDir: session.workingDir,
@@ -1599,7 +1604,8 @@ Keep it concise but comprehensive.`;
             'auto-edit': 'acceptEdits',
             'plan': 'plan',
           };
-          const permissionMode = session.permissionMode ? modeMap[session.permissionMode] : undefined;
+          const sessionMode = session.permissionMode ?? settingsManager.get('defaultPermissionMode');
+          const permissionMode = modeMap[sessionMode];
 
           runnerManager.startSession(message.sessionId, summaryPrompt, {
             workingDir: session.workingDir,

--- a/packages/server/src/settings-manager.ts
+++ b/packages/server/src/settings-manager.ts
@@ -9,7 +9,7 @@ export interface GlobalSettings {
 const DEFAULT_SETTINGS: GlobalSettings = {
   defaultThinkingEnabled: false,
   defaultModel: 'claude-opus-4-5-20250514',
-  defaultPermissionMode: 'ask',
+  defaultPermissionMode: 'plan',
 };
 
 export class SettingsManager {


### PR DESCRIPTION
## Summary
- デフォルトの Permission Mode を `ask` から `plan` に変更
- セッションアタッチ時にグローバルデフォルト設定を適切にフォールバック
- Runner 起動時にもグローバルデフォルト設定を適切にフォールバック

## Test plan
- [ ] 新しいセッションを作成
- [ ] Permission Mode が Plan になっていることを確認
- [ ] メッセージ送信後も Plan モードが維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)