### PR TITLE
feat(server): auto-allow AskUserQuestion in permission requests

### DIFF
--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
-import { createServer, isBrowserTool, type BridgeServer } from '../server.js';
+import { createServer, isBrowserTool, isAutoAllowedTool, type BridgeServer } from '../server.js';
 
 describe('BridgeServer', () => {
   let server: BridgeServer;
@@ -450,5 +450,24 @@ describe('isBrowserTool', () => {
     expect(isBrowserTool('Read')).toBe(false);
     expect(isBrowserTool('mcp__bridge__permission_prompt')).toBe(false);
     expect(isBrowserTool('mcp__some_other_tool')).toBe(false);
+  });
+});
+
+describe('isAutoAllowedTool', () => {
+  it('should return true for AskUserQuestion', () => {
+    expect(isAutoAllowedTool('AskUserQuestion')).toBe(true);
+  });
+
+  it('should return true for browser tools', () => {
+    expect(isAutoAllowedTool('mcp__bridge__browser_navigate')).toBe(true);
+    expect(isAutoAllowedTool('mcp__bridge__browser_click')).toBe(true);
+    expect(isAutoAllowedTool('browser_navigate')).toBe(true);
+  });
+
+  it('should return false for other tools', () => {
+    expect(isAutoAllowedTool('Bash')).toBe(false);
+    expect(isAutoAllowedTool('Write')).toBe(false);
+    expect(isAutoAllowedTool('Edit')).toBe(false);
+    expect(isAutoAllowedTool('Read')).toBe(false);
   });
 });

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -124,6 +124,22 @@ export function isBrowserTool(toolName: string): boolean {
 }
 
 /**
+ * Check if a tool should be auto-allowed without user permission
+ * Includes:
+ *   - Browser tools (isBrowserTool)
+ *   - AskUserQuestion (no permission needed - it's a UI interaction tool)
+ */
+export function isAutoAllowedTool(toolName: string): boolean {
+  if (isBrowserTool(toolName)) {
+    return true;
+  }
+  if (toolName === 'AskUserQuestion') {
+    return true;
+  }
+  return false;
+}
+
+/**
  * Execute a browser command via BrowserController
  */
 async function executeBrowserCommand(controller: BrowserController, command: BrowserCommand): Promise<unknown> {
@@ -1453,8 +1469,8 @@ export function createServer(options: ServerOptions): BridgeServer {
           break;
         }
 
-        // Auto-allow browser tools (built-in AgentDock feature)
-        if (isBrowserTool(message.toolName)) {
+        // Auto-allow certain tools (browser tools, AskUserQuestion, etc.)
+        if (isAutoAllowedTool(message.toolName)) {
           ws.send(JSON.stringify({
             type: 'permission_response',
             sessionId: message.sessionId,


### PR DESCRIPTION
## Summary
- Add `isAutoAllowedTool` function to centralize auto-allowed tool logic
- AskUserQuestion is now auto-allowed like browser tools, so users don't see a permission dialog for it

## Test plan
- [x] Added unit tests for `isAutoAllowedTool` function
- [x] Manual test: Connect Claude Code to AgentDock and verify AskUserQuestion no longer shows permission dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)