### PR TITLE
docs: add Development Workflow section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,10 @@ AgentDock は Claude Code などの AI エージェント CLI をブラウザか
 
 将来的には codex-cli, gemini-cli など他の AI エージェント CLI にも対応予定です。
 
+## Development Workflow
+
+機能開発は基本的にブランチを切って TDD で進める。
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Summary
- CLAUDE.md に Development Workflow セクションを追加
- 「機能開発は基本的にブランチを切って TDD で進める」というワークフローを Project Overview の直後に配置

## Test plan
- [ ] CLAUDE.md の markdown 構文が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)