### PR TITLE
feat: display git status in session header

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -8,6 +8,7 @@ import { BrowserView } from './components/BrowserView';
 import { ErrorBanner } from './components/ErrorBanner';
 import { TodoPanel } from './components/TodoPanel';
 import { ViewToggle, type SessionView } from './components/ViewToggle';
+import { GitStatusBadge } from './components/GitStatusBadge';
 import type { SidebarSession } from './components';
 import type { ImageAttachment } from './components/MessageStream';
 import './App.css';
@@ -84,6 +85,7 @@ function App() {
     globalUsage,
     screencast,
     todoState,
+    gitStatus,
     listSessions,
     createSession,
     selectSession,
@@ -308,12 +310,21 @@ function App() {
               />
             ) : (
           <>
-            {/* Session usage bar with view toggle */}
+            {/* Session usage bar with view toggle and git status */}
             <div className="px-4 py-2 bg-bg-secondary/50 border-b border-border flex items-center justify-between gap-4 text-xs text-text-secondary">
-              <ViewToggle
-                currentView={sessionView}
-                onToggle={setSessionView}
-              />
+              <div className="flex items-center gap-4">
+                <ViewToggle
+                  currentView={sessionView}
+                  onToggle={setSessionView}
+                />
+                {gitStatus && (
+                  <GitStatusBadge
+                    status={gitStatus.status}
+                    isGitRepo={gitStatus.isGitRepo}
+                    error={gitStatus.error}
+                  />
+                )}
+              </div>
               {usageInfo && (
               <div className="flex items-center gap-4">
                 <span className="font-medium text-accent-primary" title="Session total cost">

--- a/packages/client/src/components/GitStatusBadge.tsx
+++ b/packages/client/src/components/GitStatusBadge.tsx
@@ -1,0 +1,71 @@
+import type { GitStatus } from '@agent-dock/shared';
+
+export interface GitStatusBadgeProps {
+  status: GitStatus | null;
+  isGitRepo: boolean;
+  error?: string;
+}
+
+/**
+ * GitStatusBadge displays the current git repository status.
+ * Shows branch name, commit hash, and changed files count.
+ */
+export function GitStatusBadge({ status, isGitRepo, error }: GitStatusBadgeProps) {
+  // Don't show anything if not a git repo
+  if (!isGitRepo) {
+    return null;
+  }
+
+  // Show error state
+  if (error) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-accent-warning" title={error}>
+        <GitBranchIcon className="w-3.5 h-3.5" />
+        <span>Git error</span>
+      </div>
+    );
+  }
+
+  // Show loading state
+  if (!status) {
+    return (
+      <div className="flex items-center gap-1 text-xs text-text-secondary">
+        <GitBranchIcon className="w-3.5 h-3.5" />
+        <span>Loading...</span>
+      </div>
+    );
+  }
+
+  // Build tooltip with details
+  const tooltipLines = [
+    `Branch: ${status.branch}`,
+    `Commit: ${status.commitHash}`,
+  ];
+  if (status.staged !== undefined) tooltipLines.push(`Staged: ${status.staged}`);
+  if (status.unstaged !== undefined) tooltipLines.push(`Unstaged: ${status.unstaged}`);
+  if (status.untracked !== undefined) tooltipLines.push(`Untracked: ${status.untracked}`);
+  const tooltip = tooltipLines.join('\n');
+
+  return (
+    <div className="flex items-center gap-1.5 text-xs" title={tooltip}>
+      <GitBranchIcon className="w-3.5 h-3.5 text-text-secondary" />
+      <span className="text-text-primary font-medium">{status.branch}</span>
+      <span className="text-text-secondary">@</span>
+      <span className="font-mono text-text-secondary">{status.commitHash}</span>
+      {status.changedFilesCount > 0 && (
+        <span className={status.isDirty ? 'text-accent-warning' : 'text-text-secondary'}>
+          ({status.changedFilesCount} file{status.changedFilesCount !== 1 ? 's' : ''})
+        </span>
+      )}
+    </div>
+  );
+}
+
+// Git branch icon (from Heroicons)
+function GitBranchIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.493 2.493 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+    </svg>
+  );
+}

--- a/packages/server/src/__tests__/git-status-provider.test.ts
+++ b/packages/server/src/__tests__/git-status-provider.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitStatusProvider } from '../git-status-provider';
+import { spawn } from 'node:child_process';
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+describe('GitStatusProvider', () => {
+  let provider: GitStatusProvider;
+  const mockSpawn = spawn as unknown as ReturnType<typeof vi.fn>;
+
+  // Helper to create mock process that triggers callbacks immediately
+  function createMockProcess(stdout: string, exitCode = 0) {
+    const mockProc = {
+      stdout: {
+        on: vi.fn((event, callback) => {
+          if (event === 'data') {
+            // Use setImmediate to ensure async behavior
+            setImmediate(() => callback(Buffer.from(stdout)));
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn((event, callback) => {
+          if (event === 'data' && exitCode !== 0) {
+            setImmediate(() => callback(Buffer.from('error')));
+          }
+        }),
+      },
+      on: vi.fn((event, callback) => {
+        if (event === 'close') {
+          // Trigger close after stdout/stderr
+          setImmediate(() => setImmediate(() => callback(exitCode)));
+        }
+        if (event === 'error') {
+          // Don't trigger error by default
+        }
+      }),
+      kill: vi.fn(),
+    };
+    return mockProc;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    provider?.stop();
+  });
+
+  describe('getGitStatus', () => {
+    it('should return git status for a git repository', async () => {
+      // Mock responses for: rev-parse --git-dir, rev-parse --abbrev-ref, rev-parse --short, status --porcelain
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git')) // --git-dir
+        .mockReturnValueOnce(createMockProcess('feat/setup-ci\n')) // --abbrev-ref HEAD
+        .mockReturnValueOnce(createMockProcess('c85e95b\n')) // --short HEAD
+        .mockReturnValueOnce(createMockProcess('')); // status --porcelain (clean)
+
+      provider = new GitStatusProvider();
+      const result = await provider.getGitStatus('/home/user/project');
+
+      expect(result.isGitRepo).toBe(true);
+      expect(result.status).not.toBeNull();
+      expect(result.status?.branch).toBe('feat/setup-ci');
+      expect(result.status?.commitHash).toBe('c85e95b');
+      expect(result.status?.changedFilesCount).toBe(0);
+      expect(result.status?.isDirty).toBe(false);
+    });
+
+    it('should return isGitRepo false for non-git directory', async () => {
+      // --git-dir fails
+      mockSpawn.mockReturnValueOnce(createMockProcess('', 128));
+
+      provider = new GitStatusProvider();
+      const result = await provider.getGitStatus('/home/user/not-a-repo');
+
+      expect(result.isGitRepo).toBe(false);
+      expect(result.status).toBeNull();
+    });
+
+    it('should parse dirty status with staged, unstaged and untracked files', async () => {
+      const porcelainOutput = [
+        'M  staged-file.ts', // Staged modification
+        ' M unstaged-file.ts', // Unstaged modification
+        'MM both-file.ts', // Both staged and unstaged
+        '?? untracked.ts', // Untracked
+        'A  new-file.ts', // Staged new file
+      ].join('\n');
+
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('main\n'))
+        .mockReturnValueOnce(createMockProcess('abc1234\n'))
+        .mockReturnValueOnce(createMockProcess(porcelainOutput));
+
+      provider = new GitStatusProvider();
+      const result = await provider.getGitStatus('/home/user/project');
+
+      expect(result.status?.isDirty).toBe(true);
+      expect(result.status?.staged).toBe(3); // M, MM (index), A
+      expect(result.status?.unstaged).toBe(2); // M (worktree), MM (worktree)
+      expect(result.status?.untracked).toBe(1); // ??
+      expect(result.status?.changedFilesCount).toBe(6); // staged + unstaged + untracked
+    });
+
+    it('should handle detached HEAD state', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('HEAD\n')) // Detached HEAD returns "HEAD"
+        .mockReturnValueOnce(createMockProcess('abc1234\n'))
+        .mockReturnValueOnce(createMockProcess(''));
+
+      provider = new GitStatusProvider();
+      const result = await provider.getGitStatus('/home/user/project');
+
+      expect(result.status?.branch).toBe('HEAD');
+    });
+
+    it('should return error when git command fails', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('', 1)) // branch command fails
+        .mockReturnValueOnce(createMockProcess('abc1234\n'))
+        .mockReturnValueOnce(createMockProcess(''));
+
+      provider = new GitStatusProvider();
+      const result = await provider.getGitStatus('/home/user/project');
+
+      expect(result.isGitRepo).toBe(true);
+      expect(result.status).toBeNull();
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('session registration', () => {
+    it('should emit status event when session is registered', async () => {
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('main\n'))
+        .mockReturnValueOnce(createMockProcess('abc1234\n'))
+        .mockReturnValueOnce(createMockProcess(''));
+
+      provider = new GitStatusProvider();
+
+      const statusPromise = new Promise<{ sessionId: string; result: unknown }>((resolve) => {
+        provider.on('status', (sessionId, result) => {
+          resolve({ sessionId, result });
+        });
+      });
+
+      provider.registerSession('session-1', '/home/user/project');
+
+      const { sessionId, result } = await statusPromise;
+
+      expect(sessionId).toBe('session-1');
+      expect(result).toHaveProperty('isGitRepo', true);
+    });
+
+    it('should unregister session', () => {
+      provider = new GitStatusProvider();
+      provider.registerSession('session-1', '/home/user/project');
+      provider.unregisterSession('session-1');
+
+      // Should not throw and session should be removed
+      expect(() => provider.unregisterSession('session-1')).not.toThrow();
+    });
+  });
+
+  describe('polling', () => {
+    it('should start and stop without errors', () => {
+      provider = new GitStatusProvider({ interval: 5000 });
+
+      // Should not throw
+      expect(() => provider.start()).not.toThrow();
+      expect(() => provider.stop()).not.toThrow();
+
+      // Should be idempotent
+      expect(() => provider.start()).not.toThrow();
+      expect(() => provider.start()).not.toThrow();
+      expect(() => provider.stop()).not.toThrow();
+      expect(() => provider.stop()).not.toThrow();
+    });
+
+    it('should poll registered sessions after interval', async () => {
+      // Use a very short interval for testing
+      provider = new GitStatusProvider({ interval: 50 });
+
+      // First immediate fetch for session registration
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('main\n'))
+        .mockReturnValueOnce(createMockProcess('abc1234\n'))
+        .mockReturnValueOnce(createMockProcess(''));
+
+      // Second poll
+      mockSpawn
+        .mockReturnValueOnce(createMockProcess('.git'))
+        .mockReturnValueOnce(createMockProcess('main\n'))
+        .mockReturnValueOnce(createMockProcess('def5678\n'))
+        .mockReturnValueOnce(createMockProcess('M  file.ts\n'));
+
+      const statusEvents: unknown[] = [];
+      provider.on('status', (_sessionId, result) => {
+        statusEvents.push(result);
+      });
+
+      provider.registerSession('session-1', '/home/user/project');
+      provider.start();
+
+      // Wait for initial fetch
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(statusEvents.length).toBeGreaterThanOrEqual(1);
+
+      // Wait for polling interval
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(statusEvents.length).toBeGreaterThanOrEqual(2);
+
+      provider.stop();
+    });
+  });
+});

--- a/packages/server/src/git-status-provider.ts
+++ b/packages/server/src/git-status-provider.ts
@@ -1,0 +1,163 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'events';
+import type { GitStatus } from '@agent-dock/shared';
+
+export interface GitStatusResult {
+  status: GitStatus | null;
+  isGitRepo: boolean;
+  error?: string;
+}
+
+export interface GitStatusProviderOptions {
+  /** Polling interval in ms (default: 5000) */
+  interval?: number;
+}
+
+export class GitStatusProvider extends EventEmitter {
+  private intervalId: NodeJS.Timeout | null = null;
+  private sessions = new Map<string, string>(); // sessionId -> workingDir
+  private readonly interval: number;
+
+  constructor(options: GitStatusProviderOptions = {}) {
+    super();
+    this.interval = options.interval ?? 5000;
+  }
+
+  /** Register a session to track git status for */
+  registerSession(sessionId: string, workingDir: string): void {
+    this.sessions.set(sessionId, workingDir);
+    // Immediately fetch status for new session
+    this.fetchStatusForSession(sessionId, workingDir);
+  }
+
+  /** Unregister a session */
+  unregisterSession(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+
+  /** Start polling */
+  start(): void {
+    if (this.intervalId) return;
+    this.intervalId = setInterval(() => this.pollAllSessions(), this.interval);
+  }
+
+  /** Stop polling */
+  stop(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  private async pollAllSessions(): Promise<void> {
+    for (const [sessionId, workingDir] of this.sessions) {
+      await this.fetchStatusForSession(sessionId, workingDir);
+    }
+  }
+
+  private async fetchStatusForSession(sessionId: string, workingDir: string): Promise<void> {
+    try {
+      const result = await this.getGitStatus(workingDir);
+      this.emit('status', sessionId, result);
+    } catch (error) {
+      this.emit('error', sessionId, error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  async getGitStatus(workingDir: string): Promise<GitStatusResult> {
+    // Check if directory is a git repo
+    const isGitRepo = await this.isGitRepository(workingDir);
+    if (!isGitRepo) {
+      return { status: null, isGitRepo: false };
+    }
+
+    try {
+      // Run git commands in parallel for efficiency
+      const [branch, commitHash, statusOutput] = await Promise.all([
+        this.runGitCommand(workingDir, ['rev-parse', '--abbrev-ref', 'HEAD']),
+        this.runGitCommand(workingDir, ['rev-parse', '--short', 'HEAD']),
+        this.runGitCommand(workingDir, ['status', '--porcelain']),
+      ]);
+
+      // Parse status output
+      const { staged, unstaged, untracked } = this.parseStatusOutput(statusOutput);
+      const changedFilesCount = staged + unstaged + untracked;
+
+      return {
+        status: {
+          branch: branch.trim(),
+          commitHash: commitHash.trim(),
+          changedFilesCount,
+          isDirty: changedFilesCount > 0,
+          staged,
+          unstaged,
+          untracked,
+        },
+        isGitRepo: true,
+      };
+    } catch (error) {
+      return {
+        status: null,
+        isGitRepo: true,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  private async isGitRepository(workingDir: string): Promise<boolean> {
+    try {
+      await this.runGitCommand(workingDir, ['rev-parse', '--git-dir']);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private parseStatusOutput(output: string): { staged: number; unstaged: number; untracked: number } {
+    const lines = output.split('\n').filter((l) => l.trim());
+    let staged = 0;
+    let unstaged = 0;
+    let untracked = 0;
+
+    for (const line of lines) {
+      const index = line[0];
+      const worktree = line[1];
+
+      if (line.startsWith('??')) {
+        untracked++;
+      } else {
+        if (index !== ' ' && index !== '?') staged++;
+        if (worktree !== ' ' && worktree !== '?') unstaged++;
+      }
+    }
+
+    return { staged, unstaged, untracked };
+  }
+
+  private runGitCommand(workingDir: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn('git', args, {
+        cwd: workingDir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      proc.stdout.on('data', (data: Buffer) => (stdout += data.toString()));
+      proc.stderr.on('data', (data: Buffer) => (stderr += data.toString()));
+
+      proc.on('error', reject);
+      proc.on('close', (code) => {
+        if (code === 0) resolve(stdout);
+        else reject(new Error(stderr || `git exited with code ${code}`));
+      });
+
+      // Timeout after 5 seconds
+      setTimeout(() => {
+        proc.kill();
+        reject(new Error('git command timeout'));
+      }, 5000);
+    });
+  }
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -392,6 +392,8 @@ export type ServerMessage =
   | ResultMessage
   // System info
   | SystemInfoMessage
+  // Git status
+  | GitStatusMessage
   // System message (for logging)
   | SystemMessageMessage
   // Usage info
@@ -533,6 +535,38 @@ export interface SystemInfoMessage {
   permissionMode?: string;
   cwd?: string;
   tools?: string[];
+}
+
+// ==================== Git Status Messages ====================
+
+/** Git repository status information */
+export interface GitStatus {
+  /** Current branch name (e.g., "main", "feat/setup-ci") */
+  branch: string;
+  /** Short commit hash (7 chars, e.g., "c85e95b") */
+  commitHash: string;
+  /** Number of changed files (staged + unstaged + untracked) */
+  changedFilesCount: number;
+  /** Whether there are uncommitted changes */
+  isDirty: boolean;
+  /** Number of staged files */
+  staged?: number;
+  /** Number of unstaged files */
+  unstaged?: number;
+  /** Number of untracked files */
+  untracked?: number;
+}
+
+/** Git status message sent periodically from server */
+export interface GitStatusMessage {
+  type: 'git_status';
+  sessionId: string;
+  /** Git status data, null if not a git repo or error */
+  status: GitStatus | null;
+  /** Whether the working directory is a git repository */
+  isGitRepo: boolean;
+  /** Error message if git command failed */
+  error?: string;
 }
 
 export interface SystemMessageMessage {


### PR DESCRIPTION
## Summary

- Git リポジトリ内でセッションを開くと、画面上部にブランチ名・コミットハッシュ・変更ファイル数を表示
- 5秒ごとにポーリングして自動更新
- 非 Git ディレクトリでは非表示

## Implementation

- `GitStatusProvider`: サーバー側で git コマンドを実行しステータスを取得
- `GitStatusMessage`: WebSocket 経由でクライアントに送信
- `GitStatusBadge`: UI コンポーネント（ブランチアイコン + 情報表示）

## Test plan

- [ ] Git リポジトリ内でセッションを作成し、ブランチ・コミット・変更数が表示されることを確認
- [ ] ファイルを変更し、数秒後に変更ファイル数が更新されることを確認
- [ ] ブランチを切り替え、ブランチ名が更新されることを確認
- [ ] 非 Git ディレクトリでセッションを作成し、Git 情報が非表示になることを確認
- [ ] `pnpm test` が全て通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)