### PR TITLE
feat: sync permission popup dismissal across clients

### DIFF
--- a/packages/client/src/hooks/useSession.ts
+++ b/packages/client/src/hooks/useSession.ts
@@ -1176,6 +1176,22 @@ export function useSession(): UseSessionReturn {
           break;
         }
 
+        case 'permission_cleared': {
+          // Permission was resolved (allow/deny) - clear popup for all clients
+          const sessionId = message.sessionId;
+          setSessionPendingPermission((prev) => {
+            const current = prev.get(sessionId);
+            // Only clear if the requestId matches (safety check)
+            if (current && current.requestId === message.requestId) {
+              const newMap = new Map(prev);
+              newMap.delete(sessionId);
+              return newMap;
+            }
+            return prev;
+          });
+          break;
+        }
+
         case 'ask_user_question': {
           const sessionId = message.sessionId;
           setSessionPendingQuestion((prev) => {

--- a/packages/mcp-server/src/__tests__/permission-handler.test.ts
+++ b/packages/mcp-server/src/__tests__/permission-handler.test.ts
@@ -125,19 +125,6 @@ describe('PermissionHandler', () => {
       expect(result).toEqual({ behavior: 'deny', message: 'Access denied to system files' });
     });
 
-    it('should timeout if no response received', async () => {
-      handler = new PermissionHandler('ws://localhost:3001/ws', { timeout: 100 });
-      await handler.connect();
-
-      const request: PermissionRequest = {
-        sessionId: 'session-123',
-        toolName: 'Bash',
-        input: { command: 'sleep 999' },
-      };
-
-      await expect(handler.requestPermission(request)).rejects.toThrow('Permission request timed out');
-    });
-
     it('should reject if not connected', async () => {
       handler = new PermissionHandler('ws://localhost:3001/ws');
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1634,6 +1634,13 @@ export function createServer(options: ServerOptions): BridgeServer {
         // Clear the stored pending permission (no longer pending)
         sessionPendingPermissions.delete(message.sessionId);
 
+        // Broadcast permission_cleared to all clients attached to this session
+        sendToSession(message.sessionId, {
+          type: 'permission_cleared',
+          sessionId: message.sessionId,
+          requestId: message.requestId,
+        });
+
         // First check if this is for a mock runner
         const runner = runnerManager.getRunner(message.sessionId);
         if (runner && 'respondToPermission' in runner) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -414,6 +414,8 @@ export type ServerMessage =
   | GlobalUsageMessage
   // Permission request
   | PermissionRequestMessage
+  // Permission cleared (sync across clients)
+  | PermissionClearedMessage
   // AskUserQuestion
   | AskUserQuestionMessage
   // TodoWrite
@@ -606,6 +608,13 @@ export interface PermissionRequestMessage {
   requestId: string;
   toolName: string;
   input: unknown;
+}
+
+/** Broadcast when a permission request has been resolved (allow/deny) */
+export interface PermissionClearedMessage {
+  type: 'permission_cleared';
+  sessionId: string;
+  requestId: string;
 }
 
 export interface AskUserQuestionMessage {


### PR DESCRIPTION
## Summary
- Permission popup が他のクライアント（別タブ、Slack等）でも同期して消えるように
- MCP サーバーの 60 秒タイムアウトを削除（無期限に待機）
- `permission_cleared` メッセージをブロードキャストして全クライアントで同期

## Changes
- **shared**: `PermissionClearedMessage` 型追加
- **mcp-server**: timeout 削除（permission request は明示的な応答まで待機）
- **server**: `permission_response` 処理時に `permission_cleared` をブロードキャスト
- **client**: `permission_cleared` ハンドラ追加

## Test plan
- [ ] 2つのブラウザタブで同じセッションを開く
- [ ] permission request をトリガー（例: ファイル編集）
- [ ] 両タブでポップアップが表示されることを確認
- [ ] 片方で Allow/Deny
- [ ] 両タブでポップアップが消えることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)