### PR TITLE
feat: extend tool auto-allow settings

### DIFF
--- a/packages/client/src/components/SettingsPage.tsx
+++ b/packages/client/src/components/SettingsPage.tsx
@@ -151,6 +151,7 @@ export function SettingsPage({ globalSettings, updateSettings }: SettingsPagePro
     defaultThinkingEnabled: false,
     defaultRunnerBackend: 'native',
     defaultBrowserInContainer: true,
+    autoAllowWebTools: false,
   });
 
   useEffect(() => {

--- a/packages/server/src/__tests__/server.test.ts
+++ b/packages/server/src/__tests__/server.test.ts
@@ -498,10 +498,52 @@ describe('isAutoAllowedTool', () => {
     expect(isAutoAllowedTool('mcp__plugin_some_other__tool')).toBe(false);
   });
 
+  it('should return true for UI/internal tools (no system changes)', () => {
+    expect(isAutoAllowedTool('ExitPlanMode')).toBe(true);
+    expect(isAutoAllowedTool('TodoWrite')).toBe(true);
+    expect(isAutoAllowedTool('TaskOutput')).toBe(true);
+    expect(isAutoAllowedTool('EnterPlanMode')).toBe(true);
+  });
+
   it('should return false for other tools', () => {
     expect(isAutoAllowedTool('Bash')).toBe(false);
     expect(isAutoAllowedTool('Write')).toBe(false);
     expect(isAutoAllowedTool('Edit')).toBe(false);
     expect(isAutoAllowedTool('Read')).toBe(false);
+  });
+
+  it('should return false for file access tools', () => {
+    expect(isAutoAllowedTool('Glob')).toBe(false);
+    expect(isAutoAllowedTool('Grep')).toBe(false);
+  });
+
+  it('should return false for web tools by default', () => {
+    expect(isAutoAllowedTool('WebFetch')).toBe(false);
+    expect(isAutoAllowedTool('WebSearch')).toBe(false);
+  });
+});
+
+describe('isWebTool', () => {
+  // Need to import isWebTool from server.ts
+  let isWebTool: (toolName: string) => boolean;
+
+  beforeAll(async () => {
+    const serverModule = await import('../server.js');
+    isWebTool = serverModule.isWebTool;
+  });
+
+  it('should return true for WebFetch', () => {
+    expect(isWebTool('WebFetch')).toBe(true);
+  });
+
+  it('should return true for WebSearch', () => {
+    expect(isWebTool('WebSearch')).toBe(true);
+  });
+
+  it('should return false for other tools', () => {
+    expect(isWebTool('Bash')).toBe(false);
+    expect(isWebTool('Write')).toBe(false);
+    expect(isWebTool('Read')).toBe(false);
+    expect(isWebTool('AskUserQuestion')).toBe(false);
   });
 });

--- a/packages/server/src/__tests__/session-manager.test.ts
+++ b/packages/server/src/__tests__/session-manager.test.ts
@@ -64,7 +64,8 @@ describe('SessionManager', () => {
       const created = sessionManager.createSession({ name: 'Test' });
       const retrieved = sessionManager.getSession(created.id);
 
-      expect(retrieved).toEqual(created);
+      // Retrieved session may have additional fields from DB (e.g., autoAllowWebTools: null)
+      expect(retrieved).toEqual(expect.objectContaining(created));
     });
 
     it('should return undefined for non-existent session', () => {

--- a/packages/server/src/settings-manager.ts
+++ b/packages/server/src/settings-manager.ts
@@ -8,6 +8,8 @@ export interface GlobalSettings {
   defaultRunnerBackend: RunnerBackend;
   /** Default browser in container setting (true means browser runs in container when podman) */
   defaultBrowserInContainer: boolean;
+  /** Auto-allow WebFetch/WebSearch tools without permission */
+  autoAllowWebTools: boolean;
 }
 
 const DEFAULT_SETTINGS: GlobalSettings = {
@@ -16,6 +18,7 @@ const DEFAULT_SETTINGS: GlobalSettings = {
   defaultPermissionMode: 'plan',
   defaultRunnerBackend: 'native',
   defaultBrowserInContainer: true, // Default: browser follows runnerBackend
+  autoAllowWebTools: false, // Default: require permission for web tools
 };
 
 export class SettingsManager {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -783,6 +783,8 @@ export interface SessionInfo {
   runnerBackend?: RunnerBackend;
   /** Whether browser runs in container (only relevant when runnerBackend is 'podman') */
   browserInContainer?: boolean;
+  /** Session-level override for auto-allowing WebFetch/WebSearch (null = use global setting) */
+  autoAllowWebTools?: boolean | null;
 }
 
 export type SessionStatus = 'running' | 'waiting_input' | 'waiting_permission' | 'idle';
@@ -926,6 +928,8 @@ export interface GlobalSettings {
   defaultRunnerBackend: RunnerBackend;
   /** Default browser in container setting (default: true, follows runnerBackend by default) */
   defaultBrowserInContainer: boolean;
+  /** Auto-allow WebFetch/WebSearch tools without permission (default: false) */
+  autoAllowWebTools: boolean;
 }
 
 /** Client -> Server: Request to get current settings */


### PR DESCRIPTION
## Summary

- Add `ExitPlanMode`, `EnterPlanMode`, `TodoWrite`, `TaskOutput` to always auto-allowed tools (no permission popup needed)
- Add `autoAllowWebTools` setting for `WebFetch`/`WebSearch` tools:
  - Global setting in `SettingsManager` (default: false)
  - Session-level override (null = use global setting)
- Priority: session setting > global setting > default(false)

## Test plan

- [x] Type check passes (`pnpm typecheck`)
- [x] Tests pass for `isAutoAllowedTool` and `isWebTool`
- [ ] Manual test: verify ExitPlanMode, TodoWrite etc. don't show permission popup
- [ ] Manual test: verify WebFetch/WebSearch require permission by default
- [ ] Manual test: enable `autoAllowWebTools` and verify auto-allow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)