### PR TITLE
fix(ci): install chromium-headless-shell for Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: pnpm exec playwright install --with-deps chromium chromium-headless-shell
 
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
       "node-pty",
       "better-sqlite3"
     ]
+  },
+  "devDependencies": {
+    "playwright": "^1.57.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,11 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      playwright:
+        specifier: ^1.57.0
+        version: 1.57.0
 
   packages/browser-streamer:
     dependencies:


### PR DESCRIPTION
## Summary

- Install `chromium-headless-shell` in addition to `chromium` for Playwright browser installation in CI
- Use `pnpm exec` instead of `npx` to ensure the correct Playwright version from project dependencies is used

Playwright's headless mode requires `chromium-headless-shell` which was missing, causing tests to fail for `playwright-mcp` and `browser-streamer` packages.

Using `npx` was downloading Playwright 1.58.0 globally while the project uses 1.57.0, causing browser path mismatches.

Fixes #63

## Test plan

- [ ] CI passes (playwright-mcp and browser-streamer tests should pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)