### PR TITLE
fix: preserve input prompt when session creation fails

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -83,6 +83,8 @@ function App() {
     isLoading,
     loadingReason,
     error,
+    pendingMessage,
+    clearPendingMessage,
     systemInfo,
     usageInfo,
     modelUsage,
@@ -350,6 +352,7 @@ function App() {
             activeSessionId === null ? (
               /* Welcome page when no session is selected */
               <WelcomePage
+                key={error && pendingMessage ? 'error-recovery' : 'normal'}
                 sessions={sessions}
                 isConnected={isConnected}
                 onSendMessage={handleSendMessage}
@@ -363,6 +366,12 @@ function App() {
                 onPermissionModeChange={(mode) => updateSettings({ defaultPermissionMode: mode })}
                 thinkingEnabled={globalSettings?.defaultThinkingEnabled ?? false}
                 onToggleThinking={() => updateSettings({ defaultThinkingEnabled: !globalSettings?.defaultThinkingEnabled })}
+                defaultValue={error ? pendingMessage ?? undefined : undefined}
+                onValueChange={() => {
+                  if (error && pendingMessage) {
+                    clearPendingMessage();
+                  }
+                }}
               />
             ) : (
           <>

--- a/packages/client/src/components/InputArea.tsx
+++ b/packages/client/src/components/InputArea.tsx
@@ -63,6 +63,10 @@ export interface InputAreaProps {
   runnerBackend?: RunnerBackend;
   onRunnerBackendChange?: (backend: RunnerBackend) => void;
   podmanAvailable?: boolean;
+  /** Default value for the input (used to restore input on error) */
+  defaultValue?: string;
+  /** Callback when input value changes */
+  onValueChange?: (value: string) => void;
 }
 
 export function InputArea({
@@ -96,8 +100,11 @@ export function InputArea({
   runnerBackend = 'native',
   onRunnerBackendChange,
   podmanAvailable = false,
+  defaultValue,
+  onValueChange,
 }: InputAreaProps) {
-  const [value, setValue] = useState('');
+  // Use defaultValue as initial value; to reset with new defaultValue, use key prop on InputArea
+  const [value, setValue] = useState(defaultValue ?? '');
   const [showModelSelector, setShowModelSelector] = useState(false);
   const [showPermissionModeSelector, setShowPermissionModeSelector] = useState(false);
   const [showSlashCommands, setShowSlashCommands] = useState(false);
@@ -222,6 +229,7 @@ export function InputArea({
   const handleInputChange = useCallback((e: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     setValue(newValue);
+    onValueChange?.(newValue);
 
     // Detect slash command at the start
     if (newValue.startsWith('/') && !newValue.includes(' ')) {
@@ -235,7 +243,7 @@ export function InputArea({
     } else {
       setShowSlashCommands(false);
     }
-  }, []);
+  }, [onValueChange]);
 
   // Handle image file processing
   const processImageFile = useCallback((file: File): Promise<ImageAttachment | null> => {

--- a/packages/client/src/components/WelcomePage.tsx
+++ b/packages/client/src/components/WelcomePage.tsx
@@ -25,6 +25,10 @@ export interface WelcomePageProps {
   thinkingEnabled?: boolean;
   /** Callback when thinking is toggled */
   onToggleThinking?: () => void;
+  /** Default value for input (used to restore input on error) */
+  defaultValue?: string;
+  /** Callback when input value changes */
+  onValueChange?: (value: string) => void;
 }
 
 /**
@@ -47,6 +51,8 @@ export function WelcomePage({
   onPermissionModeChange,
   thinkingEnabled = false,
   onToggleThinking,
+  defaultValue,
+  onValueChange,
 }: WelcomePageProps) {
   const [selectedProject, setSelectedProject] = useState<SelectedProject | null>(null);
   const [runnerBackend, setRunnerBackend] = useState<RunnerBackend>(defaultRunnerBackend);
@@ -115,6 +121,8 @@ export function WelcomePage({
               onPermissionModeChange={onPermissionModeChange}
               thinkingEnabled={thinkingEnabled}
               onToggleThinking={onToggleThinking}
+              defaultValue={defaultValue}
+              onValueChange={onValueChange}
             />
           </div>
         </div>

--- a/packages/client/src/hooks/useSession.ts
+++ b/packages/client/src/hooks/useSession.ts
@@ -129,6 +129,8 @@ export interface UseSessionReturn {
   isLoading: boolean;
   loadingReason: 'compact' | null;
   error: string | null;
+  pendingMessage: string | null;
+  clearPendingMessage: () => void;
   systemInfo: SystemInfo | null;
   usageInfo: UsageInfo | null;
   modelUsage: ModelUsage[] | null;
@@ -1457,8 +1459,8 @@ export function useSession(): UseSessionReturn {
           break;
 
         case 'error':
-          // Only update isLoading/error for the active session
-          if (message.sessionId === activeSessionId) {
+          // Handle errors without sessionId (e.g., session creation errors) or for active session
+          if (!message.sessionId || message.sessionId === activeSessionId) {
             setError(message.message);
             setIsLoading(false);
             setLoadingReason(null);
@@ -1609,5 +1611,8 @@ export function useSession(): UseSessionReturn {
     globalSettings,
     getSettings,
     updateSettings,
+    // Pending message for error recovery
+    pendingMessage,
+    clearPendingMessage: useCallback(() => setPendingMessage(null), []),
   };
 }


### PR DESCRIPTION
## Summary
- セッション作成エラー時（git worktree 作成失敗など）に入力中のプロンプトが消えてしまう問題を修正
- `useSession` から `pendingMessage` を公開し、エラー発生時に InputArea に復元
- ユーザーが編集を開始すると `pendingMessage` をクリア
- **追加修正**: `sessionId` がないエラー（セッション作成エラー）がクライアントに表示されない問題を修正

## Test plan
- [x] 無効なリポジトリパスを登録してセッション作成を試行
- [x] エラーが表示されることを確認
- [x] エラー発生後、入力内容が保持されていることを確認
- [x] 入力を編集して再送信できることを確認

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code) from [AgentDock](https://github.com/sksat/AgentDock)