### PR TITLE
feat: improve Read and Bash tool output display

### DIFF
--- a/packages/client/src/components/MessageStream.tsx
+++ b/packages/client/src/components/MessageStream.tsx
@@ -206,15 +206,17 @@ function parsePersistedOutput(output: string): ParsedPersistedOutput | null {
  */
 function ReadToolOutput({ output, isError }: { output: string; isError: boolean }) {
   const parsedLines = useMemo(() => parseReadOutput(output), [output]);
+  // Always strip Claude Code tags for fallback display to avoid exposing internal metadata
+  const cleanOutput = useMemo(() => parseClaudeCodeTags(output).cleanOutput, [output]);
 
   if (isError || !parsedLines) {
-    // Error or unparseable output: use plain pre display
+    // Error or unparseable output: use plain pre display with tags stripped
     return (
       <pre className={clsx(
         'px-3 py-2 text-sm font-mono overflow-x-auto whitespace-pre-wrap max-h-96 overflow-y-auto',
         isError ? 'bg-accent-danger/10 text-accent-danger' : 'bg-bg-secondary text-text-secondary'
       )}>
-        {output}
+        {cleanOutput}
       </pre>
     );
   }

--- a/packages/client/src/components/__tests__/MessageStream.test.tsx
+++ b/packages/client/src/components/__tests__/MessageStream.test.tsx
@@ -1032,6 +1032,40 @@ describe('Read tool output formatting', () => {
     expect(preElement?.textContent).toContain('Some plain text output');
   });
 
+  it('should strip system-reminder tags from non-cat-n format output (fallback)', () => {
+    // When output is not cat -n format but contains system-reminder tags,
+    // the fallback <pre> display should still strip the internal metadata
+    const outputWithReminder = `Some plain text output
+<system-reminder>
+Internal reminder that should not be shown to user
+</system-reminder>`;
+
+    const messages: MessageStreamItem[] = [
+      {
+        type: 'tool',
+        content: {
+          toolName: 'Read',
+          toolUseId: 'read-1',
+          input: { file_path: '/path/to/file.ts' },
+          output: outputWithReminder,
+          isComplete: true,
+          isError: false,
+        },
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+    ];
+    const { container } = render(<MessageStream messages={messages} />);
+
+    // Should use <pre> element for non-parsed output
+    const preElement = container.querySelector('pre');
+    expect(preElement).toBeInTheDocument();
+    // Plain text should be visible
+    expect(preElement?.textContent).toContain('Some plain text output');
+    // system-reminder content should be stripped
+    expect(preElement?.textContent).not.toContain('Internal reminder');
+    expect(preElement?.textContent).not.toContain('system-reminder');
+  });
+
   it('should display error output in red with pre element', () => {
     const messages: MessageStreamItem[] = [
       {


### PR DESCRIPTION
## Summary

- **Read tool**: Display line numbers in a separate column (similar to code editors)
- **Bash tool**: Handle truncated output with structured header display
- **Claude Code tags**: Strip `<system-reminder>` content, keep `<persisted-output>` content visible

### Read tool improvements
- Parse `cat -n` format output and display line numbers in a distinct column
- Visual separation between line numbers and code content
- Fallback to plain `<pre>` for non-standard formats

### Bash tool truncated output
- Display truncated info in header: `Output  Preview (first 2KB)  ⚠ truncated (34.6KB)  Full: output.txt`
- Filename only visible, full path on hover (with `~/` simplified)
- Preview content displayed below

## Test plan
- [x] Unit tests for Read tool output parsing
- [x] Unit tests for Bash tool tag handling
- [x] Manual testing with real Claude Code output

🤖 Generated with [Claude Code](https://claude.ai/code)