### PR TITLE
fix: send Escape key instead of killing process on interrupt

### DIFF
--- a/packages/server/src/__tests__/claude-runner.test.ts
+++ b/packages/server/src/__tests__/claude-runner.test.ts
@@ -363,6 +363,31 @@ describe('ClaudeRunner', () => {
     });
   });
 
+  describe('interrupt (PTY mode)', () => {
+    it('should send Escape key to PTY', async () => {
+      const runner = new ClaudeRunner();
+      runner.start('test');
+
+      runner.interrupt();
+
+      expect(mockPty.pty.write).toHaveBeenCalledWith('\x1b');
+    });
+
+    it('should not kill the PTY process', async () => {
+      const runner = new ClaudeRunner();
+      runner.start('test');
+
+      runner.interrupt();
+
+      expect(mockPty.pty.kill).not.toHaveBeenCalled();
+    });
+
+    it('should not throw if process not started', async () => {
+      const runner = new ClaudeRunner();
+      expect(() => runner.interrupt()).not.toThrow();
+    });
+  });
+
   describe('sendInput (PTY mode)', () => {
     it('should write to PTY', async () => {
       const runner = new ClaudeRunner();

--- a/packages/server/src/__tests__/runner-manager.test.ts
+++ b/packages/server/src/__tests__/runner-manager.test.ts
@@ -13,6 +13,7 @@ vi.mock('../claude-runner.js', () => ({
       emit: emitter.emit.bind(emitter),
       start: vi.fn(),
       stop: vi.fn(),
+      interrupt: vi.fn(),
       sendInput: vi.fn(),
       isRunning: false,
     };

--- a/packages/server/src/claude-runner.ts
+++ b/packages/server/src/claude-runner.ts
@@ -309,6 +309,14 @@ export class ClaudeRunner extends EventEmitter {
     }
   }
 
+  interrupt(): void {
+    if (this.ptyProcess) {
+      // Send Escape key to interrupt Claude Code's current operation
+      // This mimics pressing Esc in the terminal
+      this.ptyProcess.write('\x1b');
+    }
+  }
+
   sendInput(input: string): void {
     if (this.ptyProcess) {
       console.log(`[ClaudeRunner] Sending input to PTY: ${input}`);

--- a/packages/server/src/mock-claude-runner.ts
+++ b/packages/server/src/mock-claude-runner.ts
@@ -195,6 +195,13 @@ export class MockClaudeRunner extends EventEmitter {
     this.emit('exit', { code: null, signal: 'SIGTERM' });
   }
 
+  interrupt(): void {
+    // Interrupt current operation without terminating the runner
+    // This simulates pressing Escape in Claude Code
+    this.stopped = true;
+    // Note: Unlike stop(), we don't emit 'exit' because the process is still alive
+  }
+
   sendInput(input: string): void {
     this.lastInput = input;
     if (this.inputResolver) {

--- a/packages/server/src/podman-claude-runner.ts
+++ b/packages/server/src/podman-claude-runner.ts
@@ -407,6 +407,16 @@ export class PodmanClaudeRunner extends EventEmitter {
   }
 
   /**
+   * Interrupt the current operation by sending Escape key.
+   */
+  interrupt(): void {
+    if (this.ptyProcess) {
+      // Send Escape key to interrupt Claude Code's current operation
+      this.ptyProcess.write('\x1b');
+    }
+  }
+
+  /**
    * Send input to the running container.
    */
   sendInput(input: string): void {

--- a/packages/server/src/runner-manager.ts
+++ b/packages/server/src/runner-manager.ts
@@ -36,6 +36,7 @@ export interface IClaudeRunner extends EventEmitter {
   readonly permissionMode: ClaudePermissionMode;
   start(prompt: string, options?: StartOptions): void;
   stop(): void;
+  interrupt(): void;
   sendInput(input: string): void;
   requestPermissionModeChange(targetMode: ClaudePermissionMode): boolean;
   on<K extends keyof ClaudeRunnerEvents>(event: K, listener: ClaudeRunnerEvents[K]): this;
@@ -113,6 +114,13 @@ export class RunnerManager {
     const runner = this.runners.get(sessionId);
     if (runner) {
       runner.stop();
+    }
+  }
+
+  interruptSession(sessionId: string): void {
+    const runner = this.runners.get(sessionId);
+    if (runner) {
+      runner.interrupt();
     }
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1927,7 +1927,9 @@ export function createServer(options: ServerOptions): BridgeServer {
           break;
         }
 
-        runnerManager.stopSession(message.sessionId);
+        // Send Escape key to interrupt Claude Code's current operation
+        // This preserves the session (unlike stopSession which kills the process)
+        runnerManager.interruptSession(message.sessionId);
         updateAndBroadcastStatus(message.sessionId, 'idle');
         response = {
           type: 'result',


### PR DESCRIPTION
## Summary

- 停止ボタンを押した時、プロセスを kill する代わりに Escape キーを PTY に送信するように修正
- これにより Claude Code で Esc を押した時と同じ動作（動作の中断のみでセッション維持）が実現される

## Changes

- `IClaudeRunner` インターフェースに `interrupt()` メソッドを追加
- `ClaudeRunner`, `PodmanClaudeRunner`, `MockClaudeRunner` に `interrupt()` を実装
- `RunnerManager` に `interruptSession()` メソッドを追加
- `server.ts` の interrupt ハンドラで `stopSession()` → `interruptSession()` に変更
- テストを追加

## Test plan

- [ ] `pnpm dev` で開発サーバーを起動
- [ ] AgentDock で Claude Code セッションを開始
- [ ] タスク実行中に停止ボタンをクリック
- [ ] 動作が中断され、セッションが維持されて再び入力可能になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)