### PR TITLE
docs: add animated logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
-# AgentDock
+<p align="center">
+  <img src="assets/agentdock-banner.svg" alt="AgentDock" width="400" />
+</p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Node.js](https://img.shields.io/badge/Node.js-24.x-green.svg)](https://nodejs.org/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue.svg)](https://www.typescriptlang.org/)
+<p align="center">
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
+  <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-24.x-green.svg" alt="Node.js" /></a>
+  <a href="https://www.typescriptlang.org/"><img src="https://img.shields.io/badge/TypeScript-5.9-blue.svg" alt="TypeScript" /></a>
+</p>
 
-A Web UI for operating Claude Code and other AI agent CLIs from your browser. Manage multiple sessions, stream outputs in real-time, and control tool permissions through an intuitive interface.
+<p align="center">
+  A Web UI for operating Claude Code and other AI agent CLIs from your browser.<br />
+  Manage multiple sessions, stream outputs in real-time, and control tool permissions.
+</p>
 
 ## Features
 

--- a/assets/agentdock-banner.svg
+++ b/assets/agentdock-banner.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 320 80" xmlns="http://www.w3.org/2000/svg">
+  <!-- ターミナルウィンドウ枠 -->
+  <rect x="5" y="5" width="90" height="70" rx="8" fill="none" stroke="#0ea5e9" stroke-width="3"/>
+
+  <!-- アンカー（プロンプト記号として） -->
+  <circle cx="20" cy="32" r="6" fill="none" stroke="#0ea5e9" stroke-width="3"/>
+  <line x1="20" y1="38" x2="20" y2="52" stroke="#0ea5e9" stroke-width="3"/>
+  <path d="M11 47 Q11 58 20 58 Q29 58 29 47" fill="none" stroke="#0ea5e9" stroke-width="3" stroke-linecap="round"/>
+
+  <!-- カーソル（点滅アニメーション） -->
+  <rect x="36" y="55" width="52" height="4" fill="#22c55e">
+    <animate attributeName="opacity" values="1;0;1;0;1;0" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833" calcMode="discrete"/>
+  </rect>
+
+  <!-- エージェントドット（明るさとサイズが連動） -->
+  <circle cx="46" cy="42" r="7" fill="#0ea5e9">
+    <animate attributeName="opacity" values="0.4;1;0.4;0.4;0.4;0.4;0.4" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+    <animate attributeName="r" values="7;9;7;7;7;7;7" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+  </circle>
+  <circle cx="64" cy="42" r="7" fill="#22c55e">
+    <animate attributeName="opacity" values="0.4;0.4;0.4;1;0.4;0.4;0.4" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+    <animate attributeName="r" values="7;7;7;9;7;7;7" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+  </circle>
+  <circle cx="82" cy="42" r="7" fill="#a855f7">
+    <animate attributeName="opacity" values="0.4;0.4;0.4;0.4;0.4;1;0.4" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+    <animate attributeName="r" values="7;7;7;7;7;9;7" dur="3s" repeatCount="indefinite" keyTimes="0;0.167;0.333;0.5;0.667;0.833;1" calcMode="spline" keySplines="0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1;0.4 0 0.6 1"/>
+  </circle>
+
+  <!-- AgentDock テキスト -->
+  <text x="115" y="52" font-family="system-ui, -apple-system, sans-serif" font-size="36" font-weight="700" fill="#0ea5e9">AgentDock</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add animated AgentDock logo to the README header
- Center-align the title, badges, and description for a polished landing page

## Test plan
- [ ] Verify logo displays correctly on GitHub README
- [ ] Check that animation works (dots and cursor blinking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)