### PR TITLE
refactor: extract ClaudeStreamProcessor for shared stream parsing

### DIFF
--- a/packages/server/src/__tests__/claude-stream-processor.test.ts
+++ b/packages/server/src/__tests__/claude-stream-processor.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ClaudeStreamProcessor } from '../claude-stream-processor.js';
+
+describe('ClaudeStreamProcessor', () => {
+  let processor: ClaudeStreamProcessor;
+
+  beforeEach(() => {
+    processor = new ClaudeStreamProcessor();
+  });
+
+  describe('handleData', () => {
+    it('should emit text event for assistant message', () => {
+      const textHandler = vi.fn();
+      processor.on('text', textHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello, world!' }],
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(textHandler).toHaveBeenCalledWith({ text: 'Hello, world!' });
+    });
+
+    it('should emit thinking event for thinking block', () => {
+      const thinkingHandler = vi.fn();
+      processor.on('thinking', thinkingHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'thinking', thinking: 'Let me think about this...' }],
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(thinkingHandler).toHaveBeenCalledWith({ thinking: 'Let me think about this...' });
+    });
+
+    it('should emit tool_use event for tool use block', () => {
+      const toolUseHandler = vi.fn();
+      processor.on('tool_use', toolUseHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{
+            type: 'tool_use',
+            id: 'tool-1',
+            name: 'Bash',
+            input: { command: 'ls' },
+          }],
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(toolUseHandler).toHaveBeenCalledWith({
+        id: 'tool-1',
+        name: 'Bash',
+        input: { command: 'ls' },
+      });
+    });
+
+    it('should emit tool_result event for user message with tool result', () => {
+      const toolResultHandler = vi.fn();
+      processor.on('tool_result', toolResultHandler);
+
+      const event = {
+        type: 'user',
+        message: {
+          content: [{
+            type: 'tool_result',
+            tool_use_id: 'tool-1',
+            content: 'file1.txt\nfile2.txt',
+            is_error: false,
+          }],
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(toolResultHandler).toHaveBeenCalledWith({
+        toolUseId: 'tool-1',
+        content: 'file1.txt\nfile2.txt',
+        isError: false,
+      });
+    });
+
+    it('should emit system event', () => {
+      const systemHandler = vi.fn();
+      processor.on('system', systemHandler);
+
+      const event = {
+        type: 'system',
+        subtype: 'init',
+        session_id: 'session-123',
+        tools: ['Bash', 'Read'],
+        model: 'claude-3-opus',
+        permissionMode: 'default',
+        cwd: '/home/user',
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(systemHandler).toHaveBeenCalledWith({
+        subtype: 'init',
+        sessionId: 'session-123',
+        tools: ['Bash', 'Read'],
+        model: 'claude-3-opus',
+        permissionMode: 'default',
+        cwd: '/home/user',
+      });
+    });
+
+    it('should emit result event', () => {
+      const resultHandler = vi.fn();
+      processor.on('result', resultHandler);
+
+      const event = {
+        type: 'result',
+        result: 'Task completed',
+        session_id: 'session-123',
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(resultHandler).toHaveBeenCalledWith({
+        result: 'Task completed',
+        sessionId: 'session-123',
+        modelUsage: undefined,
+      });
+    });
+
+    it('should emit usage event when usage data is available', () => {
+      const usageHandler = vi.fn();
+      processor.on('usage', usageHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hi' }],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_creation_input_tokens: 10,
+            cache_read_input_tokens: 5,
+          },
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(usageHandler).toHaveBeenCalledWith({
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheCreationInputTokens: 10,
+        cacheReadInputTokens: 5,
+      });
+    });
+
+    it('should handle partial lines across chunks', () => {
+      const textHandler = vi.fn();
+      processor.on('text', textHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Hello' }],
+        },
+      };
+      const jsonStr = JSON.stringify(event);
+
+      // Send data in two chunks
+      processor.handleData(jsonStr.slice(0, 10));
+      expect(textHandler).not.toHaveBeenCalled();
+
+      processor.handleData(jsonStr.slice(10) + '\n');
+      expect(textHandler).toHaveBeenCalledWith({ text: 'Hello' });
+    });
+
+    it('should filter ANSI escape sequences', () => {
+      const textHandler = vi.fn();
+      processor.on('text', textHandler);
+
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'Clean text' }],
+        },
+      };
+      // Add ANSI escape sequences around the JSON
+      processor.handleData('\x1b[32m' + JSON.stringify(event) + '\x1b[0m\n');
+
+      expect(textHandler).toHaveBeenCalledWith({ text: 'Clean text' });
+    });
+
+    it('should ignore non-JSON lines', () => {
+      const textHandler = vi.fn();
+      processor.on('text', textHandler);
+
+      processor.handleData('This is not JSON\n');
+      processor.handleData('Also not JSON\n');
+
+      expect(textHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('permission mode', () => {
+    it('should have default permission mode initially', () => {
+      expect(processor.permissionMode).toBe('default');
+    });
+
+    it('should update permission mode and emit event', () => {
+      const modeHandler = vi.fn();
+      processor.on('permission_mode_changed', modeHandler);
+
+      processor.updatePermissionMode('acceptEdits');
+
+      expect(processor.permissionMode).toBe('acceptEdits');
+      expect(modeHandler).toHaveBeenCalledWith({ permissionMode: 'acceptEdits' });
+    });
+
+    it('should handle permission mode variations', () => {
+      processor.updatePermissionMode('ask');
+      expect(processor.permissionMode).toBe('default');
+
+      processor.updatePermissionMode('auto-edit');
+      expect(processor.permissionMode).toBe('acceptEdits');
+    });
+
+    it('should not emit event for same mode', () => {
+      const modeHandler = vi.fn();
+      processor.on('permission_mode_changed', modeHandler);
+
+      processor.updatePermissionMode('default');
+
+      expect(modeHandler).not.toHaveBeenCalled();
+    });
+
+    it('should set initial permission mode', () => {
+      processor.setInitialPermissionMode('plan');
+      expect(processor.permissionMode).toBe('plan');
+    });
+
+    it('should calculate correct Shift+Tab steps for mode change', () => {
+      const writeFn = vi.fn();
+
+      // default -> acceptEdits: 1 step
+      processor.requestPermissionModeChange('acceptEdits', writeFn);
+      expect(writeFn).toHaveBeenCalledTimes(1);
+      expect(writeFn).toHaveBeenCalledWith('\x1b[Z');
+
+      writeFn.mockClear();
+      processor.setInitialPermissionMode('default');
+
+      // default -> plan: 2 steps
+      processor.requestPermissionModeChange('plan', writeFn);
+      expect(writeFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return false when no writeFn provided', () => {
+      const result = processor.requestPermissionModeChange('acceptEdits', null);
+      expect(result).toBe(false);
+    });
+
+    it('should return false when already at target mode', () => {
+      const writeFn = vi.fn();
+      const result = processor.requestPermissionModeChange('default', writeFn);
+      expect(result).toBe(false);
+      expect(writeFn).not.toHaveBeenCalled();
+    });
+
+    it('should update mode from system event', () => {
+      const modeHandler = vi.fn();
+      processor.on('permission_mode_changed', modeHandler);
+
+      const event = {
+        type: 'system',
+        permissionMode: 'plan',
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(processor.permissionMode).toBe('plan');
+      expect(modeHandler).toHaveBeenCalledWith({ permissionMode: 'plan' });
+    });
+  });
+
+  describe('buffer management', () => {
+    it('should reset buffer', () => {
+      const textHandler = vi.fn();
+      processor.on('text', textHandler);
+
+      // Send partial data
+      processor.handleData('{"type":"assistant","message":{');
+
+      // Reset buffer
+      processor.resetBuffer();
+
+      // Send complete data - should not crash due to leftover buffer
+      const event = {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'After reset' }],
+        },
+      };
+      processor.handleData(JSON.stringify(event) + '\n');
+
+      expect(textHandler).toHaveBeenCalledWith({ text: 'After reset' });
+    });
+  });
+});

--- a/packages/server/src/claude-stream-processor.ts
+++ b/packages/server/src/claude-stream-processor.ts
@@ -1,0 +1,293 @@
+/**
+ * ClaudeStreamProcessor - Processes Claude Code's stream-json output.
+ *
+ * This class handles:
+ * - Stream buffering and JSON line parsing
+ * - Event emission (text, thinking, tool_use, tool_result, etc.)
+ * - Permission mode state management
+ *
+ * Used by ClaudeRunner and PodmanClaudeRunner via composition.
+ */
+
+import { EventEmitter } from 'events';
+import { StreamEvent, type ResultModelUsage } from './stream-parser.js';
+
+// Permission mode as reported by Claude Code's system event
+export type ClaudePermissionMode = 'default' | 'acceptEdits' | 'plan';
+
+// Permission mode cycle order (Shift+Tab cycles through these)
+const PERMISSION_MODE_ORDER: ClaudePermissionMode[] = ['default', 'acceptEdits', 'plan'];
+
+export interface UsageData {
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
+export interface ControlResponse {
+  subtype: 'success' | 'error';
+  request_id: string;
+  response?: { mode?: ClaudePermissionMode };
+  error?: string;
+}
+
+export interface ClaudeStreamProcessorEvents {
+  text: (data: { text: string }) => void;
+  thinking: (data: { thinking: string }) => void;
+  tool_use: (data: { id: string; name: string; input: unknown }) => void;
+  tool_result: (data: { toolUseId: string; content: string; isError: boolean }) => void;
+  result: (data: { result: string; sessionId?: string; modelUsage?: Record<string, ResultModelUsage> }) => void;
+  system: (data: { subtype?: string; sessionId?: string; tools?: string[]; model?: string; permissionMode?: string; cwd?: string }) => void;
+  usage: (data: UsageData) => void;
+  permission_mode_changed: (data: { permissionMode: ClaudePermissionMode }) => void;
+  control_response: (data: ControlResponse) => void;
+}
+
+export class ClaudeStreamProcessor extends EventEmitter {
+  private buffer: string = '';
+  private _permissionMode: ClaudePermissionMode = 'default';
+
+  get permissionMode(): ClaudePermissionMode {
+    return this._permissionMode;
+  }
+
+  /**
+   * Set initial permission mode (called from runner's start method).
+   */
+  setInitialPermissionMode(mode: ClaudePermissionMode): void {
+    this._permissionMode = mode;
+  }
+
+  /**
+   * Reset buffer (called on runner start).
+   */
+  resetBuffer(): void {
+    this.buffer = '';
+  }
+
+  /**
+   * Handle incoming stream data from PTY or child process stdout.
+   * Buffers partial lines and processes complete JSON lines.
+   */
+  handleData(data: string): void {
+    this.buffer += data;
+    const lines = this.buffer.split('\n');
+
+    // Keep the last incomplete line in the buffer
+    this.buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      // Filter out ANSI escape sequences and control characters
+      const cleanLine = trimmed.replace(/\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\r/g, '');
+      if (cleanLine && cleanLine.startsWith('{')) {
+        this.processLine(cleanLine);
+      }
+    }
+  }
+
+  private processLine(line: string): void {
+    try {
+      const event = JSON.parse(line) as StreamEvent;
+      this.processEvent(event);
+    } catch {
+      // Ignore non-JSON lines (likely terminal control sequences)
+    }
+  }
+
+  private processEvent(event: StreamEvent): void {
+    switch (event.type) {
+      case 'system':
+        // Update internal permission mode state from Claude Code
+        if (event.permissionMode) {
+          this.updatePermissionMode(event.permissionMode);
+        }
+
+        this.emit('system', {
+          subtype: event.subtype,
+          sessionId: event.session_id,
+          tools: event.tools,
+          model: event.model,
+          permissionMode: event.permissionMode,
+          cwd: event.cwd,
+        });
+        break;
+
+      case 'assistant':
+        this.processAssistantMessage(event);
+        break;
+
+      case 'user':
+        this.processUserMessage(event);
+        break;
+
+      case 'result':
+        this.emit('result', {
+          result: event.result,
+          sessionId: event.session_id,
+          modelUsage: event.modelUsage,
+        });
+        break;
+
+      case 'control_response':
+        this.processControlResponse(event);
+        break;
+    }
+  }
+
+  private processControlResponse(event: StreamEvent): void {
+    if (event.type !== 'control_response') return;
+
+    const response = event.response;
+    console.log('[ClaudeStreamProcessor] Control response received:', JSON.stringify(response));
+
+    // Update permission mode if this was a set_permission_mode response
+    if (response.subtype === 'success' && response.response?.mode) {
+      this.updatePermissionMode(response.response.mode);
+    }
+
+    this.emit('control_response', {
+      subtype: response.subtype,
+      request_id: response.request_id,
+      response: response.response as { mode?: ClaudePermissionMode },
+      error: response.error,
+    });
+  }
+
+  private processAssistantMessage(event: StreamEvent): void {
+    if (event.type !== 'assistant') return;
+    if (!event.message?.content) return;
+
+    for (const block of event.message.content) {
+      if (block.type === 'text') {
+        this.emit('text', { text: block.text });
+      } else if (block.type === 'thinking') {
+        this.emit('thinking', { thinking: block.thinking });
+      } else if (block.type === 'tool_use') {
+        this.emit('tool_use', {
+          id: block.id,
+          name: block.name,
+          input: block.input,
+        });
+      }
+    }
+
+    // Emit usage info if available
+    if (event.message.usage) {
+      this.emit('usage', {
+        inputTokens: event.message.usage.input_tokens,
+        outputTokens: event.message.usage.output_tokens,
+        cacheCreationInputTokens: event.message.usage.cache_creation_input_tokens,
+        cacheReadInputTokens: event.message.usage.cache_read_input_tokens,
+      });
+    }
+  }
+
+  private processUserMessage(event: StreamEvent): void {
+    if (event.type !== 'user') return;
+    if (!event.message?.content) return;
+    if (typeof event.message.content === 'string') return;
+
+    for (const block of event.message.content) {
+      if (block.type === 'tool_result') {
+        this.emit('tool_result', {
+          toolUseId: block.tool_use_id,
+          content: typeof block.content === 'string' ? block.content : JSON.stringify(block.content),
+          isError: block.is_error ?? false,
+        });
+      }
+    }
+  }
+
+  /**
+   * Update permission mode from Claude Code's system event.
+   * This is called when we receive a system event with permissionMode.
+   */
+  updatePermissionMode(mode: string): void {
+    const validMode = this.parsePermissionMode(mode);
+    if (validMode && validMode !== this._permissionMode) {
+      const oldMode = this._permissionMode;
+      this._permissionMode = validMode;
+      console.log(`[ClaudeStreamProcessor] Permission mode changed: ${oldMode} -> ${validMode}`);
+      this.emit('permission_mode_changed', { permissionMode: validMode });
+    }
+  }
+
+  /**
+   * Parse permission mode string from Claude Code to our type.
+   */
+  parsePermissionMode(mode: string): ClaudePermissionMode | null {
+    if (mode === 'default' || mode === 'acceptEdits' || mode === 'plan') {
+      return mode;
+    }
+    // Handle possible variations
+    if (mode === 'normal' || mode === 'ask') {
+      return 'default';
+    }
+    if (mode === 'auto-edit' || mode === 'autoEdit') {
+      return 'acceptEdits';
+    }
+    console.log(`[ClaudeStreamProcessor] Unknown permission mode: ${mode}`);
+    return null;
+  }
+
+  /**
+   * Request permission mode change by sending Shift+Tab sequences.
+   * @param targetMode The desired permission mode
+   * @param writeFn Function to write to the PTY (injected by runner)
+   * @returns true if Shift+Tab was sent, false if already at target or no writeFn
+   */
+  requestPermissionModeChange(
+    targetMode: ClaudePermissionMode,
+    writeFn: ((data: string) => void) | null
+  ): boolean {
+    if (this._permissionMode === targetMode) {
+      return false;
+    }
+
+    if (!writeFn) {
+      console.log('[ClaudeStreamProcessor] Cannot change permission mode: no write function');
+      return false;
+    }
+
+    // Calculate how many Shift+Tab presses needed
+    const currentIndex = PERMISSION_MODE_ORDER.indexOf(this._permissionMode);
+    const targetIndex = PERMISSION_MODE_ORDER.indexOf(targetMode);
+
+    if (currentIndex === -1 || targetIndex === -1) {
+      console.log('[ClaudeStreamProcessor] Invalid permission mode');
+      return false;
+    }
+
+    // Calculate steps (cycle forward only)
+    let steps = targetIndex - currentIndex;
+    if (steps <= 0) {
+      steps += PERMISSION_MODE_ORDER.length;
+    }
+
+    console.log(`[ClaudeStreamProcessor] Sending ${steps} Shift+Tab(s) to change mode from ${this._permissionMode} to ${targetMode}`);
+
+    // Send Shift+Tab (escape sequence: \x1b[Z)
+    for (let i = 0; i < steps; i++) {
+      writeFn('\x1b[Z');
+    }
+
+    return true;
+  }
+
+  // Type-safe event emitter methods
+  override on<K extends keyof ClaudeStreamProcessorEvents>(
+    event: K,
+    listener: ClaudeStreamProcessorEvents[K]
+  ): this {
+    return super.on(event, listener);
+  }
+
+  override emit<K extends keyof ClaudeStreamProcessorEvents>(
+    event: K,
+    ...args: Parameters<ClaudeStreamProcessorEvents[K]>
+  ): boolean {
+    return super.emit(event, ...args);
+  }
+}


### PR DESCRIPTION
## Summary

- ClaudeRunner と PodmanClaudeRunner から共通のストリーム処理ロジックを ClaudeStreamProcessor として抽出
- Composition パターンにより「PodmanClaudeRunner は Claude Runner を podman で走らせる」アーキテクチャを実現
- 約150行の重複コードを削除

## Architecture

```
ClaudeRunner          PodmanClaudeRunner
    │                       │
    └──────── both use ─────┘
                │
                ▼
      ClaudeStreamProcessor
      (stream parsing, events, permission mode)
```

## Changes

| File | Change |
|------|--------|
| `claude-stream-processor.ts` | 新規作成: ストリームパース、イベント発火、パーミッション状態管理 |
| `claude-runner.ts` | processor を composition で利用するようリファクタリング |
| `podman-claude-runner.ts` | processor を composition で利用するようリファクタリング |
| `claude-stream-processor.test.ts` | 新規作成: 20のユニットテスト |

## Test plan

- [x] `claude-stream-processor.test.ts` - 20テスト全て通過
- [x] `claude-runner.test.ts` - 既存テスト全て通過
- [x] `podman-integration.test.ts` - 既存テスト全て通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)