### PR TITLE
feat(client): simplify tool use display with ToolDisplayConfig

### DIFF
--- a/packages/client/src/components/MessageStream.tsx
+++ b/packages/client/src/components/MessageStream.tsx
@@ -785,7 +785,7 @@ function ToolMessage({ content, workingDir }: { content: ToolContent; workingDir
         if (content.toolName.startsWith('mcp__')) {
           const browserInfo = formatBrowserTool(content.toolName, content.input);
           if (browserInfo) {
-            return { icon: '🌐', summary: `${browserInfo.prefix}:${browserInfo.shortName} ${browserInfo.description}`, inputDisplay: 'expanded' };
+            return { icon: '🌐', summary: `${browserInfo.prefix}:${browserInfo.shortName} ${browserInfo.description}`, inputDisplay: browserInfo.inputDisplay };
           }
           // Generic MCP tool
           const shortName = content.toolName.replace(/^mcp__[^_]+__/, '');
@@ -1020,7 +1020,7 @@ function ToolMessage({ content, workingDir }: { content: ToolContent; workingDir
 }
 
 // Helper to format browser tool display
-function formatBrowserTool(toolName: string, input: unknown): { prefix: string; shortName: string; description: string } | null {
+function formatBrowserTool(toolName: string, input: unknown): { prefix: string; shortName: string; description: string; inputDisplay: 'expanded' | 'collapsed' | 'hidden' } | null {
   // Match AgentDock bridge browser tools (mcp__bridge__browser_*)
   const bridgeMatch = toolName.match(/^mcp__bridge__browser_(.+)$/);
   // Match external MCP Playwright browser tools (mcp__plugin_playwright_*__browser_*)
@@ -1105,10 +1105,17 @@ function formatBrowserTool(toolName: string, input: unknown): { prefix: string; 
       description = '';
   }
 
+  // Determine inputDisplay based on action type
+  // navigate, snapshot, navigate_back: summary has all info -> hidden
+  // click, type, hover, etc.: show input but collapsed by default
+  const hiddenActions = ['navigate', 'navigate_back', 'snapshot', 'close', 'install'];
+  const inputDisplay: 'expanded' | 'collapsed' | 'hidden' = hiddenActions.includes(action) ? 'hidden' : 'collapsed';
+
   return {
     prefix: isExternalPlaywright ? 'playwright' : 'browser',
     shortName: action.replace(/_/g, ' '),
     description,
+    inputDisplay,
   };
 }
 

--- a/packages/client/src/components/__tests__/MessageStream.test.tsx
+++ b/packages/client/src/components/__tests__/MessageStream.test.tsx
@@ -797,7 +797,7 @@ describe('ToolMessage - Browser tool formatting', () => {
     expect(screen.getByText('some tool')).toBeInTheDocument();
   });
 
-  it('should show expanded content by default', () => {
+  it('should show expanded content by default for browser_navigate (Input hidden)', () => {
     const messages: MessageStreamItem[] = [
       {
         type: 'tool',
@@ -813,10 +813,31 @@ describe('ToolMessage - Browser tool formatting', () => {
     ];
     render(<MessageStream messages={messages} />);
 
-    // Should show Input/Output sections by default (expanded)
-    expect(screen.getByText('Input')).toBeInTheDocument();
+    // browser_navigate: Input is hidden (url is shown in summary), only Output shown
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
     expect(screen.getByText('Output')).toBeInTheDocument();
     expect(screen.getByText('Navigation successful')).toBeInTheDocument();
+  });
+
+  it('should show collapsed Input for browser_click', () => {
+    const messages: MessageStreamItem[] = [
+      {
+        type: 'tool',
+        content: {
+          toolUseId: 'tool-1',
+          toolName: 'mcp__bridge__browser_click',
+          input: { element: 'Submit button', ref: 'btn-1' },
+          output: 'Click successful',
+          isComplete: true,
+        },
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+    ];
+    render(<MessageStream messages={messages} />);
+
+    // browser_click: Input is shown (collapsed by default means it's rendered)
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('Output')).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary

- Introduce `ToolDisplayConfig` interface for cleaner tool display control
- Add `inputDisplay: 'expanded' | 'collapsed' | 'hidden'` for explicit Input section visibility
- Tools like WebSearch, Glob, Grep now hide redundant Input when all info is in header

## Changes

**New data model:**
```typescript
interface ToolDisplayConfig {
  icon: string;
  summary: string;           // Header display
  detailInput?: unknown;     // Additional input to show when expanded
  inputDisplay: 'expanded' | 'collapsed' | 'hidden';
}
```

**Behavior:**
| Tool | Before | After |
|------|--------|-------|
| WebSearch `{query}` | Shows Input JSON | Input hidden |
| WebSearch `{query, allowed_domains}` | Shows all | Shows only `allowed_domains` |
| Glob | Shows Input JSON | Input hidden |
| Grep `{pattern, path, output_mode}` | Shows all | Shows only `output_mode` |

## Test plan

- [x] Run `pnpm test` - all 428 tests pass
- [x] Type check passes
- [ ] Manual verification with dev server

🤖 Generated with [Claude Code](https://claude.ai/code)