### PR TITLE
feat(client): add connecting state and reduce reconnect interval

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -159,7 +159,7 @@ function App() {
     }
   }, [sessionView, activeSessionId, startMachineMonitor, stopMachineMonitor]);
 
-  const { isConnected, send } = useWebSocket(WS_URL, {
+  const { connectionState, isConnected, send } = useWebSocket(WS_URL, {
     onMessage: handleServerMessage,
     onConnect: () => {
       console.log('Connected to server');
@@ -286,11 +286,19 @@ function App() {
         <div className="flex items-center gap-2">
           <span
             className={`w-2 h-2 rounded-full ${
-              isConnected ? 'bg-accent-success' : 'bg-accent-danger'
+              connectionState === 'connected'
+                ? 'bg-accent-success'
+                : connectionState === 'connecting'
+                  ? 'bg-accent-warning'
+                  : 'bg-accent-danger'
             }`}
           />
           <span className="text-sm text-text-secondary">
-            {isConnected ? 'Connected' : 'Disconnected'}
+            {connectionState === 'connected'
+              ? 'Connected'
+              : connectionState === 'connecting'
+                ? 'Connecting...'
+                : 'Disconnected'}
           </span>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- Add `ConnectionState` type with 3 states: `disconnected`, `connecting`, `connected`
- Show "Connecting..." with yellow indicator while establishing WebSocket connection
- Reduce default reconnect interval from 3000ms to 1000ms for faster reconnection

## Motivation
After page reload, the UI showed "Disconnected" even while the WebSocket connection was being established. This gave users a false impression that the connection had failed, when it was actually in progress.

## Changes
- `useWebSocket.ts`: Added `connectionState` state and `ConnectionState` type
- `App.tsx`: Updated connection status indicator to show 3 states
- `useWebSocket.test.ts`: Added tests for new connection state behavior

## Test plan
- [x] Unit tests pass (`pnpm test -- useWebSocket.test.ts --run`)
- [ ] Manual test: Reload page and verify "Connecting..." appears briefly before "Connected"
- [ ] Manual test: Stop server and verify reconnection attempts happen at 1s intervals

🤖 Generated with [Claude Code](https://claude.ai/code)