### PR TITLE
fix: expose VITE_SERVER_PORT to client code in dev:stable mode

### DIFF
--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(({ mode }) => {
     define: {
       // Expose stable mode flag to client code
       'import.meta.env.VITE_STABLE_MODE': JSON.stringify(noWatch),
+      'import.meta.env.VITE_SERVER_PORT': JSON.stringify(serverPort),
     },
     server: {
       host: hostExpose ? true : undefined,


### PR DESCRIPTION
## Summary
- `pnpm dev:stable` で WebSocket 接続が失敗する問題を修正
- `vite.config.ts` の `define` セクションに `VITE_SERVER_PORT` を追加
- クライアントが正しいポート（3002）に接続できるようになった

## 原因
`VITE_SERVER_PORT` がシェル環境変数として渡されていたが、Vite の `define` で明示的に定義されていなかったため、クライアントコード (`import.meta.env.VITE_SERVER_PORT`) が `undefined` になり、デフォルトの `3001` にフォールバックしていた。

## Test plan
- [x] `pnpm dev:stable` を実行
- [x] http://localhost:5174 を開く
- [x] "Connected" と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)