### PR TITLE
fix: improve context window display reliability with fallback chain

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -88,6 +88,7 @@ function App() {
     systemInfo,
     usageInfo,
     modelUsage,
+    currentContextWindow,
     globalUsage,
     screencast,
     todoState,
@@ -544,7 +545,7 @@ function App() {
                 onModelChange={handleModelChange}
                 sessionId={session?.claudeSessionId}
                 tokenUsage={usageInfo ? { inputTokens: usageInfo.inputTokens, outputTokens: usageInfo.outputTokens } : undefined}
-                contextWindow={modelUsage?.find(m => m.modelName === systemInfo?.model)?.contextWindow}
+                contextWindow={currentContextWindow}
                 thinkingEnabled={thinkingEnabled}
                 onToggleThinking={handleToggleThinking}
                 onNewSession={() => setIsNewSessionModalOpen(true)}

--- a/packages/client/src/components/InputArea.tsx
+++ b/packages/client/src/components/InputArea.tsx
@@ -7,7 +7,7 @@ import { ProjectSelector } from './ProjectSelector';
 import { RunnerBackendToggle } from './RunnerBackendToggle';
 import type { ImageAttachment } from './MessageStream';
 import type { RunnerBackend, Repository, SelectedProject, RecentProject } from '@agent-dock/shared';
-import { calculateOccupancyRate } from '@agent-dock/shared';
+import { calculateOccupancyRate, getContextWindow } from '@agent-dock/shared';
 
 export interface TokenUsage {
   inputTokens: number;
@@ -700,10 +700,12 @@ export function InputArea({
 
               {/* Context window usage */}
               {tokenUsage && (() => {
+                // Use contextWindowProp if provided, otherwise fallback to model-limits lookup
+                const effectiveContextWindow = contextWindowProp ?? getContextWindow(model) ?? undefined;
                 const occupancy = calculateOccupancyRate(
                   tokenUsage.inputTokens,
                   model,
-                  contextWindowProp
+                  effectiveContextWindow
                 );
 
                 // Unknown model: simple token display without percentage

--- a/packages/client/src/components/__tests__/InputArea.test.tsx
+++ b/packages/client/src/components/__tests__/InputArea.test.tsx
@@ -682,4 +682,62 @@ describe('Context window occupancy', () => {
     // Should cap at 100%, not show 125%
     expect(screen.getByText('100% | 250,000 tokens')).toBeInTheDocument();
   });
+
+  it('should display pie chart for unknown model when contextWindow prop is provided', () => {
+    render(
+      <InputArea
+        onSend={() => {}}
+        model="unknown-future-model"
+        tokenUsage={{ inputTokens: 50000, outputTokens: 1000 }}
+        contextWindow={200000}
+      />
+    );
+
+    // contextWindow prop overrides unknown model fallback
+    // 50,000 / 200,000 = 25%
+    expect(screen.getByText('25% | 50,000 tokens')).toBeInTheDocument();
+  });
+
+  it('should use contextWindow prop over model-limits lookup when both available', () => {
+    render(
+      <InputArea
+        onSend={() => {}}
+        model="claude-sonnet-4-5-20250929"  // Known model: 200,000
+        tokenUsage={{ inputTokens: 50000, outputTokens: 1000 }}
+        contextWindow={100000}  // Override with smaller value
+      />
+    );
+
+    // contextWindow prop (100,000) should take precedence
+    // 50,000 / 100,000 = 50%
+    expect(screen.getByText('50% | 50,000 tokens')).toBeInTheDocument();
+  });
+
+  it('should fallback to model-limits when contextWindow prop is undefined', () => {
+    render(
+      <InputArea
+        onSend={() => {}}
+        model="claude-opus-4-5-20251101"  // Known model: 200,000
+        tokenUsage={{ inputTokens: 100000, outputTokens: 1000 }}
+      />
+    );
+
+    // No contextWindow prop, should use model-limits (200,000)
+    // 100,000 / 200,000 = 50%
+    expect(screen.getByText('50% | 100,000 tokens')).toBeInTheDocument();
+  });
+
+  it('should handle undefined model gracefully with contextWindow prop', () => {
+    render(
+      <InputArea
+        onSend={() => {}}
+        tokenUsage={{ inputTokens: 25000, outputTokens: 1000 }}
+        contextWindow={100000}
+      />
+    );
+
+    // model is undefined, but contextWindow is provided
+    // 25,000 / 100,000 = 25%
+    expect(screen.getByText('25% | 25,000 tokens')).toBeInTheDocument();
+  });
 });

--- a/packages/server/src/__tests__/mock-claude-runner.test.ts
+++ b/packages/server/src/__tests__/mock-claude-runner.test.ts
@@ -558,3 +558,96 @@ describe('Predefined scenarios', () => {
     });
   });
 });
+
+describe('Usage scenarios', () => {
+  it('should emit result with modelUsage including contextWindow', async () => {
+    const runner = MockClaudeRunner.withUsageScenario('claude-sonnet-4-20250514');
+    const resultHandler = vi.fn();
+    const systemHandler = vi.fn();
+
+    runner.on('system', systemHandler);
+    runner.on('result', resultHandler);
+
+    runner.start('test message');
+
+    await vi.waitFor(() => {
+      expect(resultHandler).toHaveBeenCalled();
+    });
+
+    expect(systemHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-sonnet-4-20250514',
+      })
+    );
+
+    expect(resultHandler).toHaveBeenCalledWith({
+      result: 'Task completed',
+      sessionId: expect.any(String),
+      modelUsage: {
+        'claude-sonnet-4-20250514': {
+          inputTokens: 50000,
+          outputTokens: 1000,
+          cacheReadInputTokens: 10000,
+          cacheCreationInputTokens: 5000,
+          contextWindow: 200000,
+        },
+      },
+    });
+  });
+
+  it('should emit result with modelUsage without contextWindow', async () => {
+    const runner = MockClaudeRunner.withUsageNoContextWindowScenario('claude-sonnet-4-20250514');
+    const resultHandler = vi.fn();
+
+    runner.on('result', resultHandler);
+
+    runner.start('test message');
+
+    await vi.waitFor(() => {
+      expect(resultHandler).toHaveBeenCalled();
+    });
+
+    expect(resultHandler).toHaveBeenCalledWith({
+      result: 'Task completed',
+      sessionId: expect.any(String),
+      modelUsage: {
+        'claude-sonnet-4-20250514': {
+          inputTokens: 50000,
+          outputTokens: 1000,
+        },
+      },
+    });
+  });
+
+  it('should work with custom model name', async () => {
+    const runner = MockClaudeRunner.withUsageScenario('claude-opus-4-5-20251101');
+    const resultHandler = vi.fn();
+    const systemHandler = vi.fn();
+
+    runner.on('system', systemHandler);
+    runner.on('result', resultHandler);
+
+    runner.start('test message');
+
+    await vi.waitFor(() => {
+      expect(resultHandler).toHaveBeenCalled();
+    });
+
+    expect(systemHandler).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'claude-opus-4-5-20251101',
+      })
+    );
+
+    expect(resultHandler).toHaveBeenCalledWith({
+      result: 'Task completed',
+      sessionId: expect.any(String),
+      modelUsage: {
+        'claude-opus-4-5-20251101': expect.objectContaining({
+          inputTokens: 50000,
+          contextWindow: 200000,
+        }),
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Context window の円グラフが出たり出なかったりする問題を修正
- サーバー側で `contextWindow` を常に送信するように変更（CLI から返されない場合は model-limits からフォールバック）
- クライアント側で `currentContextWindow` を計算・公開し、props 渡しを簡素化
- CLI の累積値を DB に永続化し、リロード時の「巻き戻り」を修正

## Problem

1. **円グラフが表示されない問題**
   - `modelUsage?.find(m => m.modelName === systemInfo?.model)?.contextWindow` という複雑なマッチングに依存
   - `systemInfo?.model` が未設定、またはモデル名が一致しない場合に表示されなかった

2. **リロード時の巻き戻り問題**
   - CLI の累積値が DB に永続化されていなかった
   - リロード後、DB の古い値が表示され、CLI から新しい値が来ると不整合が発生

## Solution

### フォールバックチェーン
1. **CLI-provided contextWindow** → 最も正確
2. **DB-persisted contextWindow** → リロード後も維持
3. **Static model-limits lookup** → 既知モデルのデフォルト値

### 累積値の永続化
- `setModelUsageCumulative()` メソッドを追加（上書きモード）
- `result` イベントで CLI の累積値を DB に保存
- リロード時に CLI と同じ値が表示される

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `packages/server/src/server.ts` | `usage_info` に常に `contextWindow` を含める、`setModelUsageCumulative` 使用 |
| `packages/server/src/session-manager.ts` | `setModelUsageCumulative()` メソッド追加（上書きモード） |
| `packages/server/src/mock-claude-runner.ts` | `ResultStep` に `modelUsage` サポート追加 |
| `packages/client/src/hooks/useSession.ts` | `currentContextWindow` を計算・公開 |
| `packages/client/src/App.tsx` | `contextWindow` props の簡素化 |
| `packages/client/src/components/InputArea.tsx` | 最終フォールバック追加 |

## Test plan

- [x] クライアントテスト pass
- [x] MockClaudeRunner の modelUsage テスト追加
- [ ] 新規セッション作成 → 円グラフ表示を確認
- [ ] ページリロード → 円グラフが復元されることを確認
- [ ] 複数ターンの会話 → 円グラフが更新されることを確認
- [ ] `/compact` 実行 → 円グラフの値が減少することを確認

🤖 Generated with [Claude Code](https://claude.ai/code) via [AgentDock](https://github.com/sksat/AgentDock)