### PR TITLE
fix: add unique IDs to messages to prevent duplicate display

### DIFF
--- a/packages/client/src/hooks/useSession.ts
+++ b/packages/client/src/hooks/useSession.ts
@@ -275,6 +275,7 @@ function convertHistoryForDisplay(history: ServerMessageItem[]): MessageStreamIt
       // All tools are merged into unified 'tool' type
       processedToolUseIds.add(content.toolUseId);
       result.push({
+        id: content.toolUseId, // Use toolUseId as stable ID for tool messages
         type: 'tool',
         content: {
           toolUseId: content.toolUseId,
@@ -294,8 +295,9 @@ function convertHistoryForDisplay(history: ServerMessageItem[]): MessageStreamIt
         processedToolUseIds.add(content.toolUseId);
       }
     } else {
-      // Pass through other message types
+      // Pass through other message types with generated IDs
       result.push({
+        id: crypto.randomUUID(),
         type: item.type as MessageStreamItem['type'],
         content: item.content,
         timestamp: item.timestamp,
@@ -375,6 +377,7 @@ export function useSession(): UseSessionReturn {
         newMap.set(activeSessionId, [
           ...current,
           {
+            id: crypto.randomUUID(),
             type: 'user',
             content: pendingMessage,
             timestamp: new Date().toISOString(),
@@ -639,6 +642,7 @@ export function useSession(): UseSessionReturn {
       updateSessionMessages(activeSessionId, (prev) => [
         ...prev,
         {
+          id: crypto.randomUUID(),
           type: 'user',
           content: messageContent,
           timestamp: new Date().toISOString(),
@@ -683,6 +687,7 @@ export function useSession(): UseSessionReturn {
       updateSessionMessages(activeSessionId, (prev) => [
         ...prev,
         {
+          id: crypto.randomUUID(),
           type: 'system',
           content,
           timestamp: new Date().toISOString(),
@@ -698,6 +703,7 @@ export function useSession(): UseSessionReturn {
     updateSessionMessages(activeSessionId, (prev) => [
       ...prev,
       {
+        id: crypto.randomUUID(),
         type: 'user',
         content: '/compact',
         timestamp: new Date().toISOString(),
@@ -757,6 +763,7 @@ export function useSession(): UseSessionReturn {
         updateSessionMessages(sessionId, (prev) => [
           ...prev,
           {
+            id: crypto.randomUUID(),
             type: 'question',
             content: questionContent,
             timestamp: new Date().toISOString(),
@@ -1177,6 +1184,7 @@ export function useSession(): UseSessionReturn {
             return [
               ...prev,
               {
+                id: crypto.randomUUID(),
                 type: 'assistant',
                 content: message.text,
                 timestamp: new Date().toISOString(),
@@ -1221,6 +1229,7 @@ export function useSession(): UseSessionReturn {
             return [
               ...prev,
               {
+                id: crypto.randomUUID(),
                 type: 'thinking',
                 content: message.thinking,
                 timestamp: new Date().toISOString(),
@@ -1238,6 +1247,7 @@ export function useSession(): UseSessionReturn {
           updateSessionMessages(sessionId, (prev) => [
             ...prev,
             {
+              id: crypto.randomUUID(),
               type: 'tool',
               content: {
                 toolUseId,
@@ -1380,6 +1390,7 @@ export function useSession(): UseSessionReturn {
           updateSessionMessages(sessionId, (prev) => [
             ...prev,
             {
+              id: crypto.randomUUID(),
               type: 'todo_update',
               content: { toolUseId, todos },
               timestamp: new Date().toISOString(),
@@ -1437,6 +1448,7 @@ export function useSession(): UseSessionReturn {
           updateSessionMessages(sessionId, (prev) => [
             ...prev,
             {
+              id: crypto.randomUUID(),
               type: 'system',
               content: message.content,
               timestamp: new Date().toISOString(),
@@ -1587,6 +1599,7 @@ export function useSession(): UseSessionReturn {
           updateSessionMessages(sessionId, (prev) => [
             ...prev,
             {
+              id: crypto.randomUUID(),
               type: 'user',
               content: {
                 text: message.content,

--- a/packages/e2e/tests/duplicate-message.spec.ts
+++ b/packages/e2e/tests/duplicate-message.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Duplicate Message Prevention', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    // Wait for WebSocket connection
+    await expect(page.getByText('Connected')).toBeVisible({ timeout: 10000 });
+  });
+
+  test('should not duplicate user messages on 2nd post', async ({ page }) => {
+    // Create session with first message
+    await page.getByRole('textbox', { name: 'Type a message...' }).fill('First message');
+    await page.getByRole('textbox', { name: 'Type a message...' }).press('Enter');
+
+    // Wait for first response
+    await expect(page.getByText('I understand your request')).toBeVisible({ timeout: 10000 });
+
+    // Send second message
+    await page.getByRole('textbox', { name: 'Type a message...' }).fill('Second message');
+    await page.getByRole('textbox', { name: 'Type a message...' }).press('Enter');
+
+    // Wait for second response
+    await expect(page.getByText('I understand your request').nth(1)).toBeVisible({ timeout: 10000 });
+
+    // Count user messages with "Second message"
+    // There should be exactly 1 instance of "Second message"
+    const secondMessageElements = page.locator('[data-testid="message-item"]').filter({
+      hasText: 'Second message'
+    });
+
+    const count = await secondMessageElements.count();
+    expect(count).toBe(1);
+  });
+
+  test('should maintain correct message count for multiple posts', async ({ page }) => {
+    const input = page.getByRole('textbox', { name: 'Type a message...' });
+    const assistantResponses = page.getByText('I understand your request');
+
+    // Send 3 messages sequentially
+    const messages = ['Message A', 'Message B', 'Message C'];
+
+    for (const msg of messages) {
+      const prevCount = await assistantResponses.count();
+
+      await input.fill(msg);
+      await input.press('Enter');
+
+      // Wait for user message to appear
+      await expect(page.getByText(msg)).toBeVisible({ timeout: 5000 });
+
+      // Wait for a new assistant response to be added
+      await expect(assistantResponses).toHaveCount(prevCount + 1, { timeout: 10000 });
+    }
+
+    // Verify each message appears exactly once
+    for (const msg of messages) {
+      const messageElements = page.locator('[data-testid="message-item"]').filter({
+        hasText: msg
+      });
+      const count = await messageElements.count();
+      expect(count).toBe(1);
+    }
+  });
+
+  test('should not duplicate messages when adding to existing conversation', async ({ page }) => {
+    // Send first message to establish baseline
+    await page.getByRole('textbox', { name: 'Type a message...' }).fill('Test message');
+    await page.getByRole('textbox', { name: 'Type a message...' }).press('Enter');
+
+    // Wait for response
+    await expect(page.getByText('I understand your request')).toBeVisible({ timeout: 10000 });
+
+    // Count all message items after first exchange
+    const messageItems = page.locator('[data-testid="message-item"]');
+    const totalBefore = await messageItems.count();
+
+    // Send another message
+    await page.getByRole('textbox', { name: 'Type a message...' }).fill('Another message');
+    await page.getByRole('textbox', { name: 'Type a message...' }).press('Enter');
+
+    // Wait for second response
+    await expect(page.getByText('I understand your request').nth(1)).toBeVisible({ timeout: 10000 });
+
+    // Count message items after second message
+    const totalAfter = await messageItems.count();
+
+    // Should add exactly 2 messages: 1 user + 1 assistant
+    // (Not 3 or more due to duplication)
+    expect(totalAfter - totalBefore).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- セッション開始後、2つ目以降の投稿で1つのメッセージが2つとして表示される不具合を修正
- 全てのメッセージ作成箇所に `crypto.randomUUID()` でユニークIDを生成
- E2Eテストを追加（重複検出用）

## Problem

`MessageStream.tsx` のキー生成が `message.id ?? ${message.type}-${message.timestamp}-${index}` となっており、`message.id` がほとんど設定されていなかった。タイムスタンプが同じミリ秒になると React のキーが衝突し、メッセージが重複表示される可能性があった。

## Changes

- `packages/client/src/hooks/useSession.ts`: 11箇所のメッセージ作成で `id: crypto.randomUUID()` を追加
- `packages/e2e/tests/duplicate-message.spec.ts`: 重複検出用のE2Eテストを追加

## Test plan

- [ ] `pnpm typecheck` - 型チェックがパス
- [ ] `pnpm test` - ユニットテストがパス
- [ ] 手動テスト - 2つ目以降のメッセージ送信で重複が発生しないことを確認

Generated with [Claude Code](https://claude.ai/code) via [AgentDock](https://github.com/sksat/AgentDock)