### PR TITLE
fix: container-browser-bridge port conflict between dev and dev:stable

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -895,14 +895,14 @@ Browser MCP もコンテナ内で動作。localhost が共有される。
 │                                                             │
 │  AgentDock Server (:3001)                                   │
 │       │                                                     │
-│       │ WebSocket (ws://localhost:3002)                     │
+│       │ WebSocket (ws://localhost:3010)                     │
 │       ▼                                                     │
 │  ┌─────────────────────────────────────────────────────┐   │
 │  │ Claude Code + Browser コンテナ                       │   │
 │  │ (claude-browser イメージ, ポートマッピング)          │   │
 │  │                                                      │   │
 │  │  ┌─────────────────┐  ┌─────────────────────────┐   │   │
-│  │  │ Claude Code     │  │ Browser Bridge (:3002)  │   │   │
+│  │  │ Claude Code     │  │ Browser Bridge (:3010)  │   │   │
 │  │  │ pnpm dev :5173  │  │ Playwright              │   │   │
 │  │  │                 │  │ → localhost:5173 ✅     │   │   │
 │  │  └─────────────────┘  └─────────────────────────┘   │   │
@@ -915,7 +915,7 @@ Browser MCP もコンテナ内で動作。localhost が共有される。
 **特徴:**
 - Browser bridge と Claude Code が同じコンテナ内で実行
 - コンテナ内の localhost が共有されるため、dev server にアクセス可能
-- ポートマッピング (`-p ${bridgePort}:3002`) でホストから bridge に接続
+- ポートマッピング (`-p ${bridgePort}:3010`) でホストから bridge に接続
 - `--network=host` を使わないため、複数セッションでポート競合しない
 
 ### コンポーネント
@@ -951,7 +951,7 @@ Browser MCP もコンテナ内で動作。localhost が共有される。
 | 変数名 | 説明 | デフォルト |
 |--------|------|-----------|
 | `BROWSER_BRIDGE_ENABLED` | Browser bridge を起動するか | `false` |
-| `BRIDGE_PORT` | Bridge のポート番号 | `3002` |
+| `BRIDGE_PORT` | Bridge のポート番号 | `3010` |
 | `GIT_USER_NAME` | Git user.name | (ホストから取得) |
 | `GIT_USER_EMAIL` | Git user.email | (ホストから取得) |
 

--- a/Dockerfile.claude-browser
+++ b/Dockerfile.claude-browser
@@ -82,7 +82,7 @@ RUN npm install && npm run build
 WORKDIR /workspace
 
 # Expose bridge port
-EXPOSE 3002
+EXPOSE 3010
 
 # Entrypoint handles Git configuration (Issue #80)
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -22,8 +22,8 @@ git config --global url."https://github.com/".insteadOf "git@github.com:" 2>/dev
 # Start browser bridge in background (Issue #78: same-container mode)
 # This allows Browser MCP and Claude Code to share the same localhost
 if [ "$BROWSER_BRIDGE_ENABLED" = "true" ]; then
-    echo "[entrypoint] Starting browser bridge on port ${BRIDGE_PORT:-3002}..."
-    BRIDGE_PORT="${BRIDGE_PORT:-3002}" node /home/node/browser-bridge/dist/index.js &
+    echo "[entrypoint] Starting browser bridge on port ${BRIDGE_PORT:-3010}..."
+    BRIDGE_PORT="${BRIDGE_PORT:-3010}" node /home/node/browser-bridge/dist/index.js &
     BRIDGE_PID=$!
     echo "[entrypoint] Browser bridge started with PID: $BRIDGE_PID"
 fi

--- a/packages/container-browser-bridge/src/index.ts
+++ b/packages/container-browser-bridge/src/index.ts
@@ -8,7 +8,7 @@ export * from './types.js';
 
 // CLI entry point
 async function main(): Promise<void> {
-  const port = parseInt(process.env.BRIDGE_PORT ?? '3002', 10);
+  const port = parseInt(process.env.BRIDGE_PORT ?? '3010', 10);
 
   console.log(`[ContainerBrowserBridge] Starting on port ${port}...`);
 

--- a/packages/server/src/__tests__/persistent-container-manager.test.ts
+++ b/packages/server/src/__tests__/persistent-container-manager.test.ts
@@ -32,7 +32,7 @@ describe('PersistentContainerManager', () => {
     manager = new PersistentContainerManager({
       containerConfig: mockContainerConfig,
       workingDir: '/test/dir',
-      bridgePort: 3002,
+      bridgePort: 3010,
     });
   });
 

--- a/packages/server/src/container-config.ts
+++ b/packages/server/src/container-config.ts
@@ -30,7 +30,7 @@ export interface ContainerConfig {
   extraArgs: string[];
   /** Enable browser bridge in the container (Issue #78: same-container mode) */
   browserBridgeEnabled?: boolean;
-  /** Bridge port number (default: 3002) */
+  /** Bridge port number (default: 3010) */
   bridgePort?: number;
 }
 
@@ -90,7 +90,7 @@ export function buildPodmanArgs(
   // With --network=host, the bridge listens directly on bridgePort on the host.
   // Each session should use a unique bridgePort to avoid conflicts.
   if (config.browserBridgeEnabled) {
-    const bridgePort = config.bridgePort ?? 3002;
+    const bridgePort = config.bridgePort ?? 3010;
     args.push('-e', 'BROWSER_BRIDGE_ENABLED=true');
     args.push('-e', `BRIDGE_PORT=${bridgePort}`);
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -614,7 +614,7 @@ export function createServer(options: ServerOptions): BridgeServer {
         const configWithBrowser: ContainerConfig = {
           ...browserContainerConfig!,
           browserBridgeEnabled: true,
-          bridgePort: opts.bridgePort ?? 3002,
+          bridgePort: opts.bridgePort ?? 3010,
         };
         return new PodmanClaudeRunner({
           workingDir: opts.workingDir,
@@ -723,7 +723,7 @@ export function createServer(options: ServerOptions): BridgeServer {
         throw new Error('Browser container mode not configured');
       }
       // Use a port based on session hash for uniqueness
-      const bridgePort = 3002 + (sessionId.charCodeAt(0) % 1000);
+      const bridgePort = 3010 + (sessionId.charCodeAt(0) % 1000);
 
       // Create a new config with browserBridgeEnabled for same-container mode (Issue #78)
       // This allows Browser MCP and dev servers to share the same localhost
@@ -1167,10 +1167,10 @@ export function createServer(options: ServerOptions): BridgeServer {
       // Get browserInContainer setting for this session (Issue #78)
       const browserInContainer = shouldUseContainerBrowser(sessionId);
 
-      // Generate unique bridge port for this session (3002-4001 range)
+      // Generate unique bridge port for this session (3010-4009 range)
       // Must match the port calculation in getOrCreateContainerManager
       const bridgePort = browserInContainer
-        ? 3002 + (sessionId.charCodeAt(0) % 1000)
+        ? 3010 + (sessionId.charCodeAt(0) % 1000)
         : undefined;
 
       // Start persistent container if browserInContainer is true (Issue #78: same-container mode)
@@ -2291,10 +2291,10 @@ export function createServer(options: ServerOptions): BridgeServer {
           // Get browserInContainer setting for this session (Issue #78)
           const browserInContainer = shouldUseContainerBrowser(message.sessionId);
 
-          // Generate unique bridge port for this session (3002-4001 range)
+          // Generate unique bridge port for this session (3010-4009 range)
           // IMPORTANT: Must match the port calculation in getOrCreateContainerManager
           const bridgePort = browserInContainer
-            ? 3002 + (message.sessionId.charCodeAt(0) % 1000)
+            ? 3010 + (message.sessionId.charCodeAt(0) % 1000)
             : undefined;
 
           // Start persistent container if browserInContainer is true (Issue #78: same-container mode)
@@ -2719,10 +2719,10 @@ Keep it concise but comprehensive.`;
           // Get browserInContainer setting for this session (Issue #78)
           const browserInContainer = shouldUseContainerBrowser(message.sessionId);
 
-          // Generate unique bridge port for this session (3002-4001 range)
+          // Generate unique bridge port for this session (3010-4009 range)
           // IMPORTANT: Must match the port calculation in getOrCreateContainerManager
           const bridgePort = browserInContainer
-            ? 3002 + (message.sessionId.charCodeAt(0) % 1000)
+            ? 3010 + (message.sessionId.charCodeAt(0) % 1000)
             : undefined;
 
           // Start persistent container if browserInContainer is true (Issue #78: same-container mode)


### PR DESCRIPTION
## Summary
- Change default bridge port from 3002 to 3010
- Port range is now 3010-4009 instead of 3002-4001
- Allows running `pnpm dev` and `pnpm dev:stable` simultaneously

Fixes #109

## Test plan
- [ ] Run `pnpm dev` (server: 3001, client: 5173)
- [ ] Run `pnpm dev:stable` in parallel (server: 3002, client: 5174)
- [ ] Verify no port conflict occurs
- [ ] Rebuild container image: `podman build -t claude-browser:v1 -f Dockerfile.claude-browser .`

Generated with [Claude Code](https://claude.ai/code) via [AgentDock](https://github.com/sksat/AgentDock)